### PR TITLE
V1

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,9 @@
   <script>
     window.APPWRITE_CFG = {
       endpoint: "https://cloud.appwrite.io/v1",
-      projectId: "<YOUR_PROJECT_ID>",
+      projectId: "68e009780030a983a57d",
       databaseId: "68e028d90039fa4588f5",
-      collectionId: "<YOUR_EVENTS_TABLE_ID>",
+      collectionId: "events",
       channel: (db, col) => `databases.${db}.collections.${col}.documents`
     };
   </script>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,18 @@
     <span>Built for Appwrite Hacktoberfest · Deployed on <strong>Sites</strong></span>
   </footer>
 
+  <!-- Appwrite SDK + config -->
+  <script src="https://cdn.jsdelivr.net/npm/appwrite@13.0.0"></script>
+  <script>
+    window.APPWRITE_CFG = {
+      endpoint: "https://cloud.appwrite.io/v1",
+      projectId: "<YOUR_PROJECT_ID>",
+      databaseId: "68e028d90039fa4588f5",
+      collectionId: "<YOUR_EVENTS_TABLE_ID>",
+      channel: (db, col) => `databases.${db}.collections.${col}.documents`
+    };
+  </script>
+
   <script src="assets/app.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
# Add Lets Talk CDC – Change Feed Playground (project repo)

## Overview
This is my **second PR** for the Hacktoberfest hackathon.

- The **first PR** submitted the project metadata (`submissions/lets-talk-cdc.md`).  
- This **second PR** contains the actual project implementation: the **Lets Talk CDC – Change Feed Playground** web app.  

## What’s Included
- **index.html** → base UI for schema editing, table state, and change event feed  
- **assets/styles.css** → dark mode layout + visual polish  
- **assets/app.js** → in-browser CDC simulator  
  - Supports inserts/updates/deletes with PK resolution  
  - Emits Debezium-style envelopes  
  - Exports/imports scenarios  
  - Seeds demo rows  
  - Appwrite Realtime integration (multi-user updates via events table)

## Project Summary
**Lets Talk CDC – Change Feed Playground** is a mini-app designed to help learners understand how CDC works:

- Build a schema, simulate DB operations, and watch the resulting change feed  
- Share events live across multiple clients using **Appwrite Realtime**  
- Deployable directly to **Appwrite Sites**

## Appwrite Products Used
- [x] Sites  
- [x] Databases (playground DB, `events` table)  
- [x] Realtime  
- [ ] Auth (not required; using public permissions for demo)

## Links
- **Submission PR:** [#6](https://github.com/appwrite-community/hf2025-hackathon-submissions/pull/6)  
- **Project repo:** [Lets-Talk-CDC-Change-Feed-Playground](https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground)  
- **Live site:** [https://letstalkcdc.appwrite.network](https://letstalkcdc.appwrite.network)
