### PR TITLE
Add event filters to Change Feed Playground

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -55,9 +55,22 @@ function buildEvent(op, before, after) {
 }
 
 function renderJSONLog() {
-  const text = state.events.map(e => JSON.stringify(e, null, 2)).join("\n");
-  els.eventLog.textContent = text || "// no events yet";
+  const allowed = {
+    c: document.getElementById("filterC")?.checked,
+    u: document.getElementById("filterU")?.checked,
+    d: document.getElementById("filterD")?.checked,
+    r: document.getElementById("filterR")?.checked,
+  };
+
+  const filtered = state.events.filter(e => {
+    const op = e.op || e.payload?.op;
+    return allowed[op] ?? true; // default true if no filter
+  });
+
+  const text = filtered.map(e => JSON.stringify(e, null, 2)).join("\n");
+  els.eventLog.textContent = text || "// no events yet (check filters)";
 }
+
 
 // ---------- Appwrite Realtime wiring ----------
 let appwrite = null;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -38,3 +38,16 @@ button:hover, .file span:hover { border-color:#2f4357; }
 
 .footer { padding:14px 20px; color:var(--muted); border-top:1px solid #223240; }
 code { background:#0f141b; padding:2px 6px; border-radius:6px; border:1px solid #223240; }
+
+.filter-actions {
+  display: flex;
+  gap: 12px;
+  margin: 8px 0;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+.filter-actions label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/index.html
+++ b/index.html
@@ -67,6 +67,12 @@
         <label><input type="checkbox" id="debzWrap" checked /> Debezium-style envelope</label>
         <label><input type="checkbox" id="includeBefore" checked /> include <code>before</code> on updates/deletes</label>
       </div>
+      <div class="filter-actions">
+        <label><input type="checkbox" id="filterC" checked /> Inserts</label>
+        <label><input type="checkbox" id="filterU" checked /> Updates</label>
+        <label><input type="checkbox" id="filterD" checked /> Deletes</label>
+        <label><input type="checkbox" id="filterR" checked /> Snapshots</label>
+      </div>
       <pre id="eventLog" class="log"></pre>
     </section>
   </main>


### PR DESCRIPTION
# Add Event Filters to Change Feed Playground

## Overview
This PR introduces a new **event filter panel** to the Change Feed Playground.  
Users can now selectively view CDC events by operation type:  
- Inserts (c)  
- Updates (u)  
- Deletes (d)  
- Snapshots (r)  

## Motivation
During testing, the event log could quickly become noisy.  
By adding filters, learners can focus on specific CDC operations and better understand the differences between change events.

## What’s Changed
- **index.html**: added filter checkboxes for event types  
- **styles.css**: styled the filter panel  
- **app.js**: updated `renderJSONLog()` to respect filter settings  

## Example
- Toggle off “Snapshots” to hide initial snapshot events and focus on change stream activity.  
- Toggle off “Deletes” if you only want to see inserts/updates.  

## Hacktoberfest Note
This PR is part of my Hacktoberfest 2025 participation.  
- The repo now has the `hacktoberfest` topic.  

## Links
- **Project Repo**: [Lets-Talk-CDC-Change-Feed-Playground](https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground)  
- **Live Site**: [https://letstalkcdc.appwrite.network](https://letstalkcdc.appwrite.network)
