### PR TITLE
Gracefully handle localStorage write errors

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -48,7 +48,13 @@ const learningConfig = [
 // ---------- Utilities ----------
 const nowTs = () => Date.now();
 const clone  = (x) => JSON.parse(JSON.stringify(x));
-const save   = () => localStorage.setItem("cdc_playground", JSON.stringify(state));
+const save   = () => {
+  try {
+    localStorage.setItem("cdc_playground", JSON.stringify(state));
+  } catch (err) {
+    console.warn("Save to localStorage failed", err?.message || err);
+  }
+};
 const load   = () => {
   try {
     const raw = localStorage.getItem("cdc_playground");


### PR DESCRIPTION
Change landed in feature/ui-learning-lab:

assets/app.js:51-57 – wrap save() in a try/catch, log the warning, and keep executing the UI refresh so new columns appear even when persistence is blocked.
Testing: node -e "const fs=require('fs');new Function(fs.readFileSync('assets/app.js','utf8'))" (syntax check).