### PR TITLE
Reorient layout around guided CDC learning path

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -20,6 +20,7 @@ const els = {
   learningSteps: document.getElementById("learningSteps"),
   learningTip: document.getElementById("learningTip"),
   schemaStatus: document.getElementById("schemaStatus"),
+  stepCards: Array.from(document.querySelectorAll(".step-card")),
 };
 
 const learningConfig = [
@@ -165,6 +166,12 @@ function updateLearning(activeId) {
   buttons.forEach(btn => {
     btn.classList.toggle("is-active", btn.dataset.step === activeIdResolved);
   });
+
+  if (els.stepCards?.length) {
+    els.stepCards.forEach(card => {
+      card.classList.toggle("is-active", card.dataset.step === activeIdResolved);
+    });
+  }
 
   const activeConfig = learningConfig.find(step => step.id === activeIdResolved);
   if (activeConfig && els.learningTip) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -219,10 +219,37 @@ button.danger:hover {
   gap: 8px;
 }
 
-.grid {
+.workspace {
   display: grid;
-  gap: clamp(18px, 4vw, 28px);
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(24px, 4vw, 48px);
+  grid-template-columns: minmax(220px, 0.85fr) minmax(0, 2.15fr);
+  align-items: start;
+}
+.workspace-panels {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+}
+.sidebar {
+  position: sticky;
+  top: clamp(24px, 6vw, 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: rgba(16, 28, 50, 0.78);
+  border: 1px solid rgba(88, 120, 177, 0.32);
+  box-shadow: 0 16px 32px -28px rgba(12, 22, 38, 0.5);
+}
+.sidebar h2 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--ink);
+}
+.sidebar-intro {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
 }
 .card {
   position: relative;
@@ -249,7 +276,46 @@ button.danger:hover {
   pointer-events: none;
 }
 .card h2 { margin: 0; font-size: 22px; }
+.card h3 { margin: 0; font-size: 18px; }
 .card-intro { margin: 0; color: var(--muted); font-size: 14px; }
+
+.step-card {
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+}
+.step-card.is-active {
+  border-color: rgba(75,163,255,0.55);
+  box-shadow: 0 22px 44px -28px rgba(32, 64, 160, 0.6);
+  transform: translateY(-2px);
+}
+.step-card-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+.step-card-header > div { display: flex; flex-direction: column; gap: 6px; }
+.step-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(75,163,255,0.16);
+  border: 1px solid rgba(75,163,255,0.46);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+.step-badge-sub {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+.step-card-divider {
+  height: 1px;
+  background: rgba(88, 120, 177, 0.28);
+  border-radius: 999px;
+}
 
 .learning-steps {
   list-style: none;
@@ -280,6 +346,7 @@ button.danger:hover {
 .learning-step.is-active {
   border-color: rgba(58,184,255,0.7);
   box-shadow: 0 18px 32px -28px rgba(12,50,110,0.9);
+  background: rgba(18,36,70,0.75);
 }
 .learning-step.is-complete { border-color: rgba(58,184,255,0.65); }
 .learning-step .step-index {
@@ -445,12 +512,15 @@ code {
 
 @media (max-width: 960px) {
   .hero { grid-template-columns: 1fr; }
+  .workspace { grid-template-columns: 1fr; }
+  .sidebar { position: static; }
 }
 
 @media (max-width: 720px) {
   .topbar { flex-direction: column; align-items: flex-start; position: static; }
   .topbar-actions { justify-content: flex-start; }
   .layout { width: min(100%, calc(100% - 24px)); padding-top: 36px; }
+  .workspace-panels { gap: 20px; }
 }
 
 @media (max-width: 520px) {

--- a/index.html
+++ b/index.html
@@ -44,83 +44,17 @@
       </div>
     </section>
 
-    <div class="grid">
-      <!-- Schema + Row editor -->
-      <section class="card" id="schema">
-        <h2>Design your schema</h2>
-        <p class="card-intro">Add columns, types, and primary keys to shape the dataset your change feed will track.</p>
-        <div class="schema">
-          <input id="colName" placeholder="column name (e.g., id)" />
-          <select id="colType">
-            <option value="string">string</option>
-            <option value="number">number</option>
-            <option value="boolean">boolean</option>
-          </select>
-          <label class="checkbox"><input type="checkbox" id="colPK" /> PK</label>
-          <button id="addCol" type="button">Add Column</button>
-        </div>
-
-        <p class="schema-status" id="schemaStatus" aria-live="polite"></p>
-
-        <div class="pill-row" id="schemaPills"></div>
-
-        <h2>Operate on table</h2>
-        <p class="card-intro">Craft row-level events by editing values below, then choose an operation.</p>
-        <div class="row-editor" id="rowEditor"></div>
-        <div class="ops">
-          <button id="opInsert" type="button">Insert</button>
-          <button id="opUpdate" type="button">Update by PK</button>
-          <button id="opDelete" type="button">Delete by PK</button>
-        </div>
-      </section>
-
-      <!-- Table state -->
-      <section class="card" id="table-state">
-        <h2>Current table</h2>
-        <p class="card-intro">Review the data backing your scenario or populate seed rows to get started quickly.</p>
-        <table id="tbl" class="data-table">
-          <thead></thead>
-          <tbody></tbody>
-        </table>
-        <div class="table-actions">
-          <button id="seedRows" type="button">Seed sample rows</button>
-          <button id="clearRows" type="button">Clear rows</button>
-        </div>
-      </section>
-
-      <!-- Change feed -->
-      <section class="card" id="change-feed">
-        <h2>Change events</h2>
-        <p class="card-intro">Toggle envelopes, filter by operation, or broadcast to Appwrite Realtime for multi-client demos.</p>
-        <div class="stream-actions">
-          <button id="emitSnapshot" type="button">Emit Snapshot</button>
-          <button id="clearEvents" type="button">Clear events</button>
-          <label class="checkbox"><input type="checkbox" id="debzWrap" checked /> Debezium-style envelope</label>
-          <label class="checkbox"><input type="checkbox" id="includeBefore" checked /> include <code>before</code> on updates/deletes</label>
-        </div>
-        <div class="filter-actions">
-          <label class="checkbox"><input type="checkbox" id="filterC" checked /> Inserts</label>
-          <label class="checkbox"><input type="checkbox" id="filterU" checked /> Updates</label>
-          <label class="checkbox"><input type="checkbox" id="filterD" checked /> Deletes</label>
-          <label class="checkbox"><input type="checkbox" id="filterR" checked /> Snapshots</label>
-        </div>
-        <div class="export-actions">
-          <button id="btnCopyNdjson" type="button">Copy NDJSON</button>
-          <button id="btnDownloadNdjson" type="button">Download NDJSON</button>
-        </div>
-        <pre id="eventLog" class="log"></pre>
-      </section>
-
-      <section class="card" id="learning-lab">
-        <h2>Learning lab</h2>
-        <p class="card-intro">Move through the CDC workflow one step at a time and use the tips to reinforce what you learn.</p>
+    <section class="workspace" id="playground">
+      <aside class="sidebar" aria-labelledby="learningTitle">
+        <h2 id="learningTitle">Learning path</h2>
+        <p class="sidebar-intro">Work through each step to understand how change data capture scenarios are assembled.</p>
         <ol class="learning-steps" id="learningSteps">
           <li>
             <button type="button" class="learning-step" data-step="schema" data-target="#schema">
               <span class="step-index">1</span>
               <span class="step-body">
                 <span class="step-title">Model your schema</span>
-                <span class="step-detail">Add columns and mark primary keys to describe data shape.</span>
+                <span class="step-detail">Define columns plus primary keys.</span>
               </span>
               <span class="step-status" aria-live="polite">Pending</span>
             </button>
@@ -129,8 +63,8 @@
             <button type="button" class="learning-step" data-step="rows" data-target="#table-state">
               <span class="step-index">2</span>
               <span class="step-body">
-                <span class="step-title">Populate the table</span>
-                <span class="step-detail">Seed sample rows or insert your own records to work with.</span>
+                <span class="step-title">Populate rows</span>
+                <span class="step-detail">Seed or insert data to operate on.</span>
               </span>
               <span class="step-status" aria-live="polite">Pending</span>
             </button>
@@ -139,16 +73,106 @@
             <button type="button" class="learning-step" data-step="events" data-target="#change-feed">
               <span class="step-index">3</span>
               <span class="step-body">
-                <span class="step-title">Emit change events</span>
-                <span class="step-detail">Run inserts, updates, deletes, or snapshots and review the log.</span>
+                <span class="step-title">Inspect events</span>
+                <span class="step-detail">Trigger operations and review the log.</span>
               </span>
               <span class="step-status" aria-live="polite">Pending</span>
             </button>
           </li>
         </ol>
         <div class="learning-tip" id="learningTip">Add at least one column to begin building your scenario.</div>
-      </section>
-    </div>
+      </aside>
+
+      <div class="workspace-panels">
+        <!-- Schema + Row editor -->
+        <section class="card step-card" data-step="schema" id="schema">
+          <header class="step-card-header">
+            <span class="step-badge">Step 1</span>
+            <div>
+              <h2>Model your schema</h2>
+              <p class="card-intro">Add columns, choose types, and mark primary keys so downstream operations know how to locate rows.</p>
+            </div>
+          </header>
+          <div class="schema">
+            <input id="colName" placeholder="column name (e.g., id)" />
+            <select id="colType">
+              <option value="string">string</option>
+              <option value="number">number</option>
+              <option value="boolean">boolean</option>
+            </select>
+            <label class="checkbox"><input type="checkbox" id="colPK" /> PK</label>
+            <button id="addCol" type="button">Add Column</button>
+          </div>
+
+          <p class="schema-status" id="schemaStatus" aria-live="polite"></p>
+
+          <div class="pill-row" id="schemaPills"></div>
+
+          <div class="step-card-divider"></div>
+
+          <header class="step-card-header">
+            <span class="step-badge step-badge-sub">Operate</span>
+            <div>
+              <h3>Edit row values</h3>
+              <p class="card-intro">Provide values for your columns, then choose an operation to emit events.</p>
+            </div>
+          </header>
+          <div class="row-editor" id="rowEditor"></div>
+          <div class="ops">
+            <button id="opInsert" type="button">Insert</button>
+            <button id="opUpdate" type="button">Update by PK</button>
+            <button id="opDelete" type="button">Delete by PK</button>
+          </div>
+        </section>
+
+        <!-- Table state -->
+        <section class="card step-card" data-step="rows" id="table-state">
+          <header class="step-card-header">
+            <span class="step-badge">Step 2</span>
+            <div>
+              <h2>Populate the table</h2>
+              <p class="card-intro">Review current rows, seed realistic data, or clear the table to reset.</p>
+            </div>
+          </header>
+          <table id="tbl" class="data-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+          <div class="table-actions">
+            <button id="seedRows" type="button">Seed sample rows</button>
+            <button id="clearRows" type="button">Clear rows</button>
+          </div>
+        </section>
+
+        <!-- Change feed -->
+        <section class="card step-card" data-step="events" id="change-feed">
+          <header class="step-card-header">
+            <span class="step-badge">Step 3</span>
+            <div>
+              <h2>Inspect change events</h2>
+              <p class="card-intro">Filter operations, include before-images, and export NDJSON to share scenarios.</p>
+            </div>
+          </header>
+          <div class="stream-actions">
+            <button id="emitSnapshot" type="button">Emit Snapshot</button>
+            <button id="clearEvents" type="button">Clear events</button>
+            <label class="checkbox"><input type="checkbox" id="debzWrap" checked /> Debezium-style envelope</label>
+            <label class="checkbox"><input type="checkbox" id="includeBefore" checked /> include <code>before</code> on updates/deletes</label>
+          </div>
+          <div class="filter-actions">
+            <label class="checkbox"><input type="checkbox" id="filterC" checked /> Inserts</label>
+            <label class="checkbox"><input type="checkbox" id="filterU" checked /> Updates</label>
+            <label class="checkbox"><input type="checkbox" id="filterD" checked /> Deletes</label>
+            <label class="checkbox"><input type="checkbox" id="filterR" checked /> Snapshots</label>
+          </div>
+          <div class="export-actions">
+            <button id="btnCopyNdjson" type="button">Copy NDJSON</button>
+            <button id="btnDownloadNdjson" type="button">Download NDJSON</button>
+          </div>
+          <pre id="eventLog" class="log"></pre>
+        </section>
+      </div>
+    </section>
   </main>
 
   <footer class="footer">


### PR DESCRIPTION
Simplified the layout by introducing a sticky Learning Path sidebar and aligning the schema, table, and change-feed panels with their guided steps.
Calmed the visual tone of the hero, cards, and controls while keeping the quick-start checklist visible.
Synced active states between the sidebar steps and the corresponding workspace panels to reinforce the learning flow.
Tests
node -e "const fs=require('fs');new Function(fs.readFileSync('assets/app.js','utf8'))"