### PR TITLE
Feature/cdc overhaul

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -489,7 +489,15 @@ button.danger:hover {
   line-height: 1.5;
 }
 
-.schema { display: flex; gap: 10px; flex-wrap: wrap; }
+.schema {
+  display: grid;
+  grid-template-columns: minmax(200px, 320px) minmax(120px, 200px) auto auto;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-start;
+  width: fit-content;
+  max-width: 100%;
+}
 .schema-status {
   min-height: 18px;
   margin: 0 0 4px;
@@ -672,7 +680,10 @@ code {
     width: 100%;
     justify-content: center;
   }
-  .schema { flex-direction: column; }
+  .schema {
+    display: flex;
+    flex-direction: column;
+  }
   .ops,
   .table-actions,
   .stream-actions,

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -548,12 +548,28 @@ select:focus {
 
 .export-actions { margin-top: 8px; }
 
-.data-table {
-  width: 100%;
-  border-collapse: collapse;
+.table-shell {
   border: 1px solid rgba(78,116,173,0.35);
   border-radius: 16px;
+  background: rgba(14, 26, 48, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(15,28,52,0.25);
   overflow: hidden;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-radius: inherit;
+}
+
+.table-scroll:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
 }
 .data-table th,
 .data-table td {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -562,6 +562,25 @@ select:focus {
   background: rgba(14, 26, 48, 0.6);
   box-shadow: inset 0 0 0 1px rgba(15,28,52,0.25);
   overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-radius: inherit;
+  width: 100%;
+}
+
+.table-scroll:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
 }
 
 .table-scroll {

--- a/index.html
+++ b/index.html
@@ -136,10 +136,14 @@
               <p class="card-intro">Review current rows, seed realistic data, or clear the table to reset.</p>
             </div>
           </header>
-          <table id="tbl" class="data-table">
-            <thead></thead>
-            <tbody></tbody>
-          </table>
+          <div class="table-shell">
+            <div class="table-scroll" role="region" aria-label="Current rows" tabindex="0">
+              <table id="tbl" class="data-table">
+                <thead></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
           <div class="table-actions">
             <button id="seedRows" type="button">Seed sample rows</button>
             <button id="clearRows" type="button">Clear rows</button>


### PR DESCRIPTION
## Summary
- wrap the Step 2 rows table in a fixed-width scroll container so step cards no longer spill past the viewport
- migrate table chrome to the wrapper and keep keyboard focus styling for horizontal scroll
- convert the schema editor row to a compact grid so column name/type controls stay tidy while retaining the stacked mobile layout

## Testing
- Manual: seed rows with many columns; confirm Step 2 and 3 cards align with the workspace edge and the table scrolls horizontally inside the card
- Manual: resize below 520px; verify the schema controls stack vertically as before
