### PR TITLE
Feature/cdc overhaul

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -562,6 +562,25 @@ select:focus {
   background: rgba(14, 26, 48, 0.6);
   box-shadow: inset 0 0 0 1px rgba(15,28,52,0.25);
   overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-radius: inherit;
+  width: 100%;
+}
+
+.table-scroll:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
 }
 
 .table-scroll {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -491,12 +491,12 @@ button.danger:hover {
 
 .schema {
   display: grid;
-  grid-template-columns: minmax(200px, 320px) minmax(120px, 200px) auto auto;
-  gap: 10px;
+  grid-template-columns: minmax(200px, 1.6fr) minmax(120px, 1fr) auto auto;
+  gap: 12px;
   align-items: center;
   justify-content: flex-start;
-  width: fit-content;
-  max-width: 100%;
+  width: 100%;
+  max-width: 640px;
 }
 .schema-status {
   min-height: 18px;
@@ -507,18 +507,24 @@ button.danger:hover {
 .schema-status.is-error { color: var(--danger); }
 .schema-status.is-success { color: var(--accent); }
 .pill-row {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   margin-bottom: 4px;
 }
 .pill {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
   background: rgba(18,34,64,0.6);
   border: 1px dashed rgba(78,116,173,0.5);
   padding: 6px 12px;
   border-radius: 999px;
   font-size: 12px;
   color: var(--muted);
+  text-align: center;
+  min-height: 32px;
 }
 .pill .pk { color: var(--accent-yellow); margin-left: 6px; }
 
@@ -690,6 +696,17 @@ code {
   .topbar-actions { justify-content: flex-start; }
   .layout { width: min(100%, calc(100% - 24px)); padding-top: 36px; }
   .workspace-panels { gap: 20px; }
+}
+
+@media (max-width: 600px) {
+  .schema {
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+  }
+  .schema > * {
+    width: 100%;
+  }
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
## Summary
- wrap the Step 2 rows table in a full-width scroll container so step cards stay within the workspace while retaining keyboard focus styling
- dial in the Step 1 grid (column name/type inputs, PK toggle, add button) so it fills the card without overextending, including a mobile fallback
- distribute schema column pills via a responsive grid for balanced wrapping

## Testing
- Manual: seed rows with many columns; verify Step 2/3 cards align with the workspace edge and the table scrolls horizontally inside the card
- Manual: resize the page below 600px; confirm the Step 1 controls stack and pills remain accessible
