### PR TITLE
Trim default schema to a compact six-column set

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -5,11 +5,6 @@
 const DEFAULT_SCHEMA = [
   { name: "id", type: "number", pk: true },
   { name: "customer_name", type: "string", pk: false },
-  { name: "customer_email", type: "string", pk: false },
-  { name: "customer_since", type: "string", pk: false },
-  { name: "paper_grade", type: "string", pk: false },
-  { name: "paper_size", type: "string", pk: false },
-  { name: "sheet_count", type: "number", pk: false },
   { name: "price_per_unit", type: "number", pk: false },
   { name: "order_total", type: "number", pk: false },
   { name: "sales_rep", type: "string", pk: false },
@@ -857,6 +852,10 @@ function generateSampleRow() {
   const row = {};
   for (const col of state.schema) {
     row[col.name] = randomSampleForColumn(col);
+  }
+  if (typeof row.price_per_unit === "number" && typeof row.order_total === "number") {
+    const quantity = Math.floor(Math.random() * 40) + 5;
+    row.order_total = Number((row.price_per_unit * quantity).toFixed(2));
   }
   return row;
 }


### PR DESCRIPTION
Start scenarios with id, customer_name, price_per_unit, order_total, sales_rep, and region so the step card stays within the viewport while keeping the Dunder Mifflin flavor. Regenerate seeded data with the lean schema and recompute order totals from the sampled price-per-unit.