### PR TITLE
Add simulator build tooling and scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+node_modules/
+assets/generated/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ A zero-dependency web app that simulates CDC operations and emits Debezium-style
 ## Run locally
 Open `index.html` in a browser. No build step.
 
+### Simulator bundle
+- Install tooling: `npm install`
+- Build the simulator modules: `npm run build:sim`
+
+The build emits `assets/generated/sim-bundle.js`, which `assets/sim-loader.js` loads on demand so the existing UI can access the TypeScript engines.
+
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).
 - Browse open issues labeled `hacktoberfest`, `good first issue`, or `help wanted` to find a place to jump in.

--- a/assets/sim-loader.js
+++ b/assets/sim-loader.js
@@ -1,0 +1,27 @@
+(function attachSimulatorLoader(global) {
+  if (global.__LetstalkCdcSimulator?.load) return;
+
+  const bundleHref = "./assets/generated/sim-bundle.js";
+
+  async function loadBundle() {
+    if (global.__LetstalkCdcSimulatorBundle) {
+      return global.__LetstalkCdcSimulatorBundle;
+    }
+
+    try {
+      const mod = await import(bundleHref);
+      const resolved = mod?.default ?? mod;
+      if (resolved) {
+        global.__LetstalkCdcSimulatorBundle = resolved;
+      }
+      return resolved;
+    } catch (error) {
+      console.warn(
+        "Simulator bundle not found. Run `npm install` and `npm run build:sim` to generate assets/generated/sim-bundle.js.",
+      );
+      throw error;
+    }
+  }
+
+  global.__LetstalkCdcSimulator = { load: loadBundle };
+})(typeof window !== "undefined" ? window : globalThis);

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,0 +1,28 @@
+# Implementation Next Steps
+
+_Tooling status: Vite (library mode) builds `sim/bundle.ts` into `assets/generated/sim-bundle.js` via `npm run build:sim`._
+
+## Immediate Decisions
+- **Legacy ↔ Vite boundary**: define which parts of `assets/app.js` migrate first and how data flows between vanilla DOM state and the Vite-powered simulator bundle while React work ramps.
+- **State container**: confirm whether we use lightweight emitter only or layer Zustand/RxJS before multi-lane comparator work starts.
+- **React integration strategy**: outline migration path from the current DOM-driven UI to React components, including carve-out plan for coexisting approaches during the transition.
+
+## Near-Term Build Goals
+1. Wire ScenarioRunner + engines into a thin React shell (served via Vite) that renders a single-lane simulator using stub metrics, then hydrate it into the existing page.
+2. Introduce deterministic clock/tick loop with pause/resume to support guided tour scripting.
+3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
+4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.
+
+## Harness Track
+- Flesh out generator/verifier packages with scripts to pull the shared scenario JSON and emit PASS/FAIL.
+- Add health checks + simple Makefile commands so `docker-compose up` yields deterministic order of operations.
+- Plan for HTML report rendering (likely React server components or static template).
+
+## Telemetry + Copy
+- Define client-side event dispatcher (post-build) and evaluate storage destination (optional backend vs privacy-preserving client log).
+- Draft copy for “honest callouts” and “when to use which” sections so UI and docs share the canonical text.
+
+## Risks to Monitor
+- Dual-stack UI (legacy DOM + future React) diverging—set kill date for legacy path.
+- Container start-up timing in harness causing flaky verification—add retries/backoff guidance.
+- Performance of timeline rendering with >1k events—prototype virtualization approach early.

--- a/harness/connectors/debezium-postgres.json
+++ b/harness/connectors/debezium-postgres.json
@@ -1,0 +1,19 @@
+{
+  "name": "debezium-postgres-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "tasks.max": "1",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "postgres",
+    "database.dbname": "demo",
+    "database.server.name": "dbserver1",
+    "schema.include.list": "public",
+    "table.include.list": "public.customers",
+    "tombstones.on.delete": "true",
+    "plugin.name": "pgoutput",
+    "slot.name": "cdc_slot",
+    "publication.autocreate.mode": "filtered"
+  }
+}

--- a/harness/docker-compose.yml
+++ b/harness/docker-compose.yml
@@ -1,0 +1,69 @@
+version: "3.8"
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: demo
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./generator/init.sql:/docker-entrypoint-initdb.d/01-init.sql
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,EXTERNAL://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  connect:
+    image: debezium/connect:2.6
+    depends_on:
+      - kafka
+    ports:
+      - "8083:8083"
+    environment:
+      BOOTSTRAP_SERVERS: kafka:29092
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: connect-configs
+      OFFSET_STORAGE_TOPIC: connect-offsets
+      STATUS_STORAGE_TOPIC: connect-status
+      KEY_CONVERTER_SCHEMAS_ENABLE: "false"
+      VALUE_CONVERTER_SCHEMAS_ENABLE: "false"
+
+  generator:
+    build: ./generator
+    depends_on:
+      - postgres
+    environment:
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: demo
+
+  verifier:
+    build: ./verifier
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_BROKERS: kafka:29092
+      TOPIC: dbserver1.public.customers
+    ports:
+      - "8089:8089"

--- a/harness/generator/Dockerfile
+++ b/harness/generator/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+CMD ["node", "generator.js"]

--- a/harness/generator/generator.js
+++ b/harness/generator/generator.js
@@ -1,0 +1,45 @@
+import pg from "pg";
+import fs from "fs";
+
+const scenarioPath = process.env.SCENARIO || "./scenario.json";
+const scenario = JSON.parse(fs.readFileSync(scenarioPath, "utf8"));
+
+const client = new pg.Client({
+  host: process.env.PGHOST || "localhost",
+  user: process.env.PGUSER || "postgres",
+  password: process.env.PGPASSWORD || "postgres",
+  database: process.env.PGDATABASE || "demo",
+});
+
+await client.connect();
+
+const start = Date.now();
+
+for (const op of scenario.ops) {
+  const wait = Math.max(0, start + op.t - Date.now());
+  if (wait) await new Promise(resolve => setTimeout(resolve, wait));
+
+  if (op.op === "insert") {
+    await client.query(
+      `insert into customers(id, name, email, updated_at, deleted)
+       values($1, $2, $3, now(), false)
+       on conflict (id)
+       do update set name = excluded.name, email = excluded.email, updated_at = now()`,
+      [op.pk.id, op.after.name || null, op.after.email || null],
+    );
+  } else if (op.op === "update") {
+    await client.query(
+      `update customers
+         set name = $2,
+             email = $3,
+             updated_at = now()
+       where id = $1`,
+      [op.pk.id, op.after.name || null, op.after.email || null],
+    );
+  } else if (op.op === "delete") {
+    await client.query(`delete from customers where id = $1`, [op.pk.id]);
+  }
+}
+
+await client.end();
+console.log("scenario complete");

--- a/harness/generator/init.sql
+++ b/harness/generator/init.sql
@@ -1,0 +1,8 @@
+create schema if not exists public;
+create table if not exists customers (
+  id text primary key,
+  name text,
+  email text,
+  updated_at timestamptz default now(),
+  deleted boolean default false
+);

--- a/harness/generator/package.json
+++ b/harness/generator/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdc-generator",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "pg": "^8.11.5"
+  }
+}

--- a/harness/scenario.json
+++ b/harness/scenario.json
@@ -1,0 +1,26 @@
+{
+  "name": "crud-basic",
+  "seed": 42,
+  "ops": [
+    {
+      "t": 100,
+      "op": "insert",
+      "table": "customers",
+      "pk": { "id": "1" },
+      "after": { "name": "A", "email": "a@example.com" }
+    },
+    {
+      "t": 400,
+      "op": "update",
+      "table": "customers",
+      "pk": { "id": "1" },
+      "after": { "name": "A1" }
+    },
+    {
+      "t": 700,
+      "op": "delete",
+      "table": "customers",
+      "pk": { "id": "1" }
+    }
+  ]
+}

--- a/harness/verifier/Dockerfile
+++ b/harness/verifier/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+CMD ["node", "index.js"]

--- a/harness/verifier/index.js
+++ b/harness/verifier/index.js
@@ -1,0 +1,61 @@
+import { Kafka } from "kafkajs";
+import http from "http";
+
+const brokers = (process.env.KAFKA_BROKERS || "localhost:9092").split(",");
+const topic = process.env.TOPIC || "dbserver1.public.customers";
+
+const kafka = new Kafka({ clientId: "verifier", brokers });
+const consumer = kafka.consumer({ groupId: "verifier" });
+
+const received = [];
+const startedAt = Date.now();
+
+function serveReport() {
+  const server = http.createServer((_req, res) => {
+    const report = {
+      total: received.length,
+      deletes: received.filter(msg => msg.op === "d").length,
+      ordering_ok: isOrdered(received),
+      first_event_ms: received[0]?.ts_ms ? received[0].ts_ms - startedAt : null,
+    };
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(report, null, 2));
+  });
+
+  server.listen(8089, () => {
+    console.log("verifier report on 8089");
+  });
+}
+
+function isOrdered(msgs) {
+  let prev = -Infinity;
+  for (const msg of msgs) {
+    const lsn = msg.tx?.lsn ?? null;
+    if (lsn != null) {
+      if (lsn < prev) return false;
+      prev = lsn;
+    }
+  }
+  return true;
+}
+
+(async () => {
+  await consumer.connect();
+  await consumer.subscribe({ topic, fromBeginning: true });
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      try {
+        const val = message.value?.toString();
+        if (!val) return;
+        const parsed = JSON.parse(val);
+        const op = parsed.op === "c" ? "c" : parsed.op === "u" ? "u" : parsed.op === "d" ? "d" : "r";
+        const lsn = parsed?.source?.lsn || parsed?.source?.sequence || null;
+        received.push({ op, ts_ms: parsed.ts_ms || Date.now(), tx: { lsn } });
+      } catch (err) {
+        console.warn("verifier parse error", err);
+      }
+    },
+  });
+
+  serveReport();
+})();

--- a/harness/verifier/package.json
+++ b/harness/verifier/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdc-verifier",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "kafkajs": "^2.2.4"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -274,6 +274,7 @@
     };
   </script>
 
+  <script src="assets/sim-loader.js"></script>
   <script src="assets/app.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,957 @@
+{
+  "name": "lets-talk-cdc-playground",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lets-talk-cdc-playground",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.4.5",
+        "vite": "^5.2.9"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lets-talk-cdc-playground",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build:sim": "vite build",
+    "preview:sim": "vite preview",
+    "dev:sim": "vite" 
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.9"
+  }
+}

--- a/sim/bundle.ts
+++ b/sim/bundle.ts
@@ -1,0 +1,47 @@
+import {
+  EventBus,
+  PollingEngine,
+  TriggerEngine,
+  LogEngine,
+  ScenarioRunner,
+} from "./index";
+import type {
+  CdcEvent,
+  SourceOp,
+  AuditRow,
+  WalRecord,
+  Row,
+} from "./core/types";
+import type {
+  MethodEngine,
+  Scenario,
+  ScenarioRunner as ScenarioRunnerApi,
+} from "./core/interfaces";
+
+const exportsObject = {
+  EventBus,
+  PollingEngine,
+  TriggerEngine,
+  LogEngine,
+  ScenarioRunner,
+};
+
+// Attach for non-module consumers once the bundle loads.
+if (typeof window !== "undefined") {
+  (window as any).__LetstalkCdcSimulatorBundle = exportsObject;
+}
+
+export type {
+  CdcEvent,
+  SourceOp,
+  AuditRow,
+  WalRecord,
+  Row,
+  MethodEngine,
+  Scenario,
+  ScenarioRunnerApi,
+};
+
+export { EventBus, PollingEngine, TriggerEngine, LogEngine, ScenarioRunner };
+
+export default exportsObject;

--- a/sim/core/EventBus.ts
+++ b/sim/core/EventBus.ts
@@ -1,0 +1,14 @@
+type Handler<T> = (event: T) => void;
+
+export class EventBus<T> {
+  private handlers = new Set<Handler<T>>();
+
+  emit(event: T) {
+    this.handlers.forEach(handler => handler(event));
+  }
+
+  on(handler: Handler<T>) {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+}

--- a/sim/core/interfaces.ts
+++ b/sim/core/interfaces.ts
@@ -1,0 +1,24 @@
+import { CdcEvent, SourceOp } from "./types";
+
+export interface MethodEngine {
+  name: "polling" | "trigger" | "log";
+  configure(opts: Record<string, any>): void;
+  reset(seed: number): void;
+  applySourceOp(op: SourceOp): void;
+  tick(nowMs: number): void;
+  onEvent(cb: (e: CdcEvent) => void): () => void;
+}
+
+export interface Scenario {
+  name: string;
+  seed: number;
+  ops: SourceOp[];
+}
+
+export interface ScenarioRunner {
+  load(s: Scenario): void;
+  start(): void;
+  pause(): void;
+  reset(seed: number): void;
+  onTick(cb: (nowMs: number) => void): void;
+}

--- a/sim/core/types.ts
+++ b/sim/core/types.ts
@@ -1,0 +1,45 @@
+export type Row = {
+  id: string;
+  data: Record<string, any>;
+  version: number;
+  updated_at_ms: number;
+  deleted: boolean;
+};
+
+export type SourceOp =
+  | { t: number; op: "insert"; table: string; pk: { id: string }; after: Record<string, any> }
+  | { t: number; op: "update"; table: string; pk: { id: string }; after: Record<string, any> }
+  | { t: number; op: "delete"; table: string; pk: { id: string } };
+
+export type CdcEvent = {
+  source: string;
+  table: string;
+  op: "c" | "u" | "d";
+  pk: { id: string };
+  before: Record<string, any> | null;
+  after: Record<string, any> | null;
+  ts_ms: number;
+  tx: { id: string; lsn: number | null };
+  seq: number;
+  meta: { method: "polling" | "trigger" | "log" };
+};
+
+export type AuditRow = {
+  audit_id: string;
+  op: "c" | "u" | "d";
+  pk: { id: string };
+  before: Record<string, any> | null;
+  after: Record<string, any> | null;
+  tx_id: string;
+  commit_ts_ms: number;
+};
+
+export type WalRecord = {
+  lsn: number;
+  tx_id: string;
+  op: "c" | "u" | "d";
+  pk: { id: string };
+  before: Record<string, any> | null;
+  after: Record<string, any> | null;
+  commit_ts_ms: number;
+};

--- a/sim/engines/LogEngine.ts
+++ b/sim/engines/LogEngine.ts
@@ -1,0 +1,97 @@
+import { BaseEngine } from "./base";
+import { CdcEvent, Row, SourceOp, WalRecord } from "../core/types";
+
+export class LogEngine extends BaseEngine {
+  name = "log" as const;
+
+  private table = new Map<string, Row>();
+  private wal: WalRecord[] = [];
+  private lsn = 0;
+  private fetchIntervalMs = 100;
+  private lastFetch = 0;
+
+  configure(opts: { fetch_interval_ms?: number }) {
+    if (opts.fetch_interval_ms !== undefined) this.fetchIntervalMs = opts.fetch_interval_ms;
+  }
+
+  applySourceOp(op: SourceOp) {
+    if (op.op === "insert") {
+      this.table.set(op.pk.id, {
+        id: op.pk.id,
+        data: op.after,
+        version: 1,
+        updated_at_ms: op.t,
+        deleted: false,
+      });
+      this.wal.push({
+        lsn: ++this.lsn,
+        tx_id: `tx-${op.t}`,
+        op: "c",
+        pk: op.pk,
+        before: null,
+        after: op.after,
+        commit_ts_ms: op.t,
+      });
+    } else if (op.op === "update") {
+      const cur = this.table.get(op.pk.id);
+      const before = cur ? { ...cur.data } : null;
+      const next = cur ? { ...cur.data, ...op.after } : op.after;
+
+      this.table.set(op.pk.id, {
+        id: op.pk.id,
+        data: next,
+        version: (cur?.version ?? 0) + 1,
+        updated_at_ms: op.t,
+        deleted: false,
+      });
+
+      this.wal.push({
+        lsn: ++this.lsn,
+        tx_id: `tx-${op.t}`,
+        op: "u",
+        pk: op.pk,
+        before,
+        after: next,
+        commit_ts_ms: op.t,
+      });
+    } else if (op.op === "delete") {
+      const cur = this.table.get(op.pk.id);
+      this.table.delete(op.pk.id);
+
+      this.wal.push({
+        lsn: ++this.lsn,
+        tx_id: `tx-${op.t}`,
+        op: "d",
+        pk: op.pk,
+        before: cur ? cur.data : null,
+        after: null,
+        commit_ts_ms: op.t,
+      });
+    }
+  }
+
+  tick(nowMs: number) {
+    if (nowMs - this.lastFetch < this.fetchIntervalMs) return;
+
+    const toEmit = this.wal.slice(this.seq);
+
+    for (const record of toEmit) {
+      const evt: CdcEvent = {
+        source: "demo-db",
+        table: "customers",
+        op: record.op,
+        pk: record.pk,
+        before: record.before,
+        after: record.after,
+        ts_ms: record.commit_ts_ms,
+        tx: { id: record.tx_id, lsn: record.lsn },
+        seq: ++this.seq,
+        meta: { method: "log" },
+      };
+
+      this.bus.emit(evt);
+    }
+
+    this.lastFetch = nowMs;
+  }
+}

--- a/sim/engines/PollingEngine.ts
+++ b/sim/engines/PollingEngine.ts
@@ -1,0 +1,76 @@
+import { BaseEngine } from "./base";
+import { CdcEvent, Row, SourceOp } from "../core/types";
+
+export class PollingEngine extends BaseEngine {
+  name = "polling" as const;
+
+  private table = new Map<string, Row>();
+  private lastSync = 0;
+  private pollIntervalMs = 1000;
+  private includeSoftDeletes = false;
+
+  configure(opts: { poll_interval_ms?: number; include_soft_deletes?: boolean }) {
+    if (opts.poll_interval_ms !== undefined) this.pollIntervalMs = opts.poll_interval_ms;
+    if (opts.include_soft_deletes !== undefined) this.includeSoftDeletes = opts.include_soft_deletes;
+  }
+
+  applySourceOp(op: SourceOp) {
+    if (op.op === "insert") {
+      this.table.set(op.pk.id, {
+        id: op.pk.id,
+        data: op.after,
+        version: 1,
+        updated_at_ms: op.t,
+        deleted: false,
+      });
+    } else if (op.op === "update") {
+      const cur = this.table.get(op.pk.id);
+      if (!cur || cur.deleted) return;
+      this.table.set(op.pk.id, {
+        ...cur,
+        data: { ...cur.data, ...op.after },
+        version: cur.version + 1,
+        updated_at_ms: op.t,
+      });
+    } else if (op.op === "delete") {
+      const cur = this.table.get(op.pk.id);
+      if (!cur) return;
+      this.table.set(op.pk.id, {
+        ...cur,
+        deleted: true,
+        updated_at_ms: op.t,
+      });
+    }
+  }
+
+  private shouldPoll(nowMs: number) {
+    return nowMs - this.lastSync >= this.pollIntervalMs;
+  }
+
+  tick(nowMs: number) {
+    if (!this.shouldPoll(nowMs)) return;
+
+    const changed = [...this.table.values()].filter(r => r.updated_at_ms > this.lastSync);
+
+    for (const row of changed) {
+      if (row.deleted && !this.includeSoftDeletes) continue;
+
+      const evt: CdcEvent = {
+        source: "demo-db",
+        table: "customers",
+        op: row.deleted ? "d" : row.version > 1 ? "u" : "c",
+        pk: { id: row.id },
+        before: null,
+        after: row.deleted ? null : row.data,
+        ts_ms: row.updated_at_ms,
+        tx: { id: `tx-${row.updated_at_ms}`, lsn: null },
+        seq: ++this.seq,
+        meta: { method: "polling" },
+      };
+
+      this.bus.emit(evt);
+    }
+
+    this.lastSync = nowMs;
+  }
+}

--- a/sim/engines/TriggerEngine.ts
+++ b/sim/engines/TriggerEngine.ts
@@ -1,0 +1,118 @@
+import { BaseEngine } from "./base";
+import { AuditRow, CdcEvent, Row, SourceOp } from "../core/types";
+
+export class TriggerEngine extends BaseEngine {
+  name = "trigger" as const;
+
+  private table = new Map<string, Row>();
+  private audit: AuditRow[] = [];
+  private extractOffset = 0;
+  private extractIntervalMs = 500;
+  private lastExtract = 0;
+  private triggerOverheadMs = 5;
+
+  configure(opts: { extract_interval_ms?: number; trigger_overhead_ms?: number }) {
+    if (opts.extract_interval_ms !== undefined) this.extractIntervalMs = opts.extract_interval_ms;
+    if (opts.trigger_overhead_ms !== undefined) this.triggerOverheadMs = opts.trigger_overhead_ms;
+  }
+
+  applySourceOp(op: SourceOp) {
+    const commitTs = op.t + this.triggerOverheadMs;
+
+    if (op.op === "insert") {
+      this.table.set(op.pk.id, {
+        id: op.pk.id,
+        data: op.after,
+        version: 1,
+        updated_at_ms: commitTs,
+        deleted: false,
+      });
+
+      this.audit.push({
+        audit_id: cryptoRandomId(),
+        op: "c",
+        pk: op.pk,
+        before: null,
+        after: op.after,
+        tx_id: `tx-${commitTs}`,
+        commit_ts_ms: commitTs,
+      });
+    } else if (op.op === "update") {
+      const cur = this.table.get(op.pk.id);
+      const before = cur ? { ...cur.data } : null;
+      const next = cur ? { ...cur.data, ...op.after } : op.after;
+
+      this.table.set(op.pk.id, {
+        id: op.pk.id,
+        data: next,
+        version: (cur?.version ?? 0) + 1,
+        updated_at_ms: commitTs,
+        deleted: false,
+      });
+
+      this.audit.push({
+        audit_id: cryptoRandomId(),
+        op: "u",
+        pk: op.pk,
+        before,
+        after: next,
+        tx_id: `tx-${commitTs}`,
+        commit_ts_ms: commitTs,
+      });
+    } else if (op.op === "delete") {
+      const cur = this.table.get(op.pk.id) || {
+        id: op.pk.id,
+        data: {},
+        version: 0,
+        updated_at_ms: commitTs,
+        deleted: true,
+      };
+
+      this.table.set(op.pk.id, {
+        ...cur,
+        deleted: true,
+        updated_at_ms: commitTs,
+      });
+
+      this.audit.push({
+        audit_id: cryptoRandomId(),
+        op: "d",
+        pk: op.pk,
+        before: cur ? cur.data : null,
+        after: null,
+        tx_id: `tx-${commitTs}`,
+        commit_ts_ms: commitTs,
+      });
+    }
+  }
+
+  tick(nowMs: number) {
+    if (nowMs - this.lastExtract < this.extractIntervalMs) return;
+
+    const batch = this.audit.slice(this.extractOffset);
+
+    for (const entry of batch) {
+      const evt: CdcEvent = {
+        source: "demo-db",
+        table: "customers",
+        op: entry.op,
+        pk: entry.pk,
+        before: entry.before,
+        after: entry.after,
+        ts_ms: entry.commit_ts_ms,
+        tx: { id: entry.tx_id, lsn: null },
+        seq: ++this.seq,
+        meta: { method: "trigger" },
+      };
+
+      this.bus.emit(evt);
+    }
+
+    this.extractOffset = this.audit.length;
+    this.lastExtract = nowMs;
+  }
+}
+
+function cryptoRandomId() {
+  return Math.random().toString(36).slice(2);
+}

--- a/sim/engines/base.ts
+++ b/sim/engines/base.ts
@@ -1,0 +1,25 @@
+import { MethodEngine } from "../core/interfaces";
+import { CdcEvent, SourceOp } from "../core/types";
+import { EventBus } from "../core/EventBus";
+
+export abstract class BaseEngine implements MethodEngine {
+  abstract name: "polling" | "trigger" | "log";
+
+  protected bus = new EventBus<CdcEvent>();
+  protected seq = 0;
+  protected randomSeed = 42;
+
+  configure(_opts: Record<string, any>) {}
+
+  reset(seed: number) {
+    this.seq = 0;
+    this.randomSeed = seed;
+  }
+
+  onEvent(cb: (e: CdcEvent) => void) {
+    return this.bus.on(cb);
+  }
+
+  abstract applySourceOp(op: SourceOp): void;
+  abstract tick(nowMs: number): void;
+}

--- a/sim/index.ts
+++ b/sim/index.ts
@@ -1,0 +1,7 @@
+export { EventBus } from "./core/EventBus";
+export type { CdcEvent, SourceOp, AuditRow, WalRecord, Row } from "./core/types";
+export type { MethodEngine, Scenario, ScenarioRunner as ScenarioRunnerApi } from "./core/interfaces";
+export { PollingEngine } from "./engines/PollingEngine";
+export { TriggerEngine } from "./engines/TriggerEngine";
+export { LogEngine } from "./engines/LogEngine";
+export { ScenarioRunner } from "./scenario/ScenarioRunner";

--- a/sim/scenario/ScenarioRunner.ts
+++ b/sim/scenario/ScenarioRunner.ts
@@ -1,0 +1,55 @@
+import { ScenarioRunner as ScenarioRunnerInterface, Scenario } from "../core/interfaces";
+import { MethodEngine } from "../core/interfaces";
+
+export class ScenarioRunner implements ScenarioRunnerInterface {
+  private scenario: Scenario | null = null;
+  private engines: MethodEngine[] = [];
+  private idx = 0;
+  private now = 0;
+  private playing = false;
+  private onTickCb?: (nowMs: number) => void;
+
+  attach(engines: MethodEngine[]) {
+    this.engines = engines;
+  }
+
+  load(scenario: Scenario) {
+    this.scenario = scenario;
+    this.idx = 0;
+    this.now = 0;
+    this.playing = false;
+  }
+
+  reset(seed: number) {
+    this.engines.forEach(engine => engine.reset(seed));
+    this.idx = 0;
+    this.now = 0;
+  }
+
+  onTick(cb: (nowMs: number) => void) {
+    this.onTickCb = cb;
+  }
+
+  start() {
+    this.playing = true;
+  }
+
+  pause() {
+    this.playing = false;
+  }
+
+  tick(deltaMs: number) {
+    if (!this.playing || !this.scenario) return;
+
+    this.now += deltaMs;
+    const { ops } = this.scenario;
+
+    while (this.idx < ops.length && ops[this.idx].t <= this.now) {
+      const op = ops[this.idx++];
+      this.engines.forEach(engine => engine.applySourceOp(op));
+    }
+
+    this.engines.forEach(engine => engine.tick(this.now));
+    this.onTickCb?.(this.now);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": []
+  },
+  "include": [
+    "sim/**/*.ts"
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    outDir: "assets/generated",
+    emptyOutDir: true,
+    lib: {
+      entry: "sim/bundle.ts",
+      name: "LetsTalkCdcSimulator",
+      formats: ["es"],
+      fileName: () => "sim-bundle.js",
+    },
+    rollupOptions: {
+      external: [],
+    },
+  },
+});

--- a/web/components/MetricsStrip.tsx
+++ b/web/components/MetricsStrip.tsx
@@ -1,0 +1,17 @@
+export function MetricsStrip(props: {
+  lagMs: number;
+  throughput: number;
+  deletesPct: number;
+  orderingOk: boolean;
+  consistent: boolean;
+}) {
+  return (
+    <div role="status" aria-live="polite">
+      <span>Lag: {props.lagMs}ms</span> ·
+      <span>TPS: {props.throughput.toFixed(1)}</span> ·
+      <span>Deletes: {Math.round(props.deletesPct)}%</span> ·
+      <span>Ordering: {props.orderingOk ? "OK" : "KO"}</span> ·
+      <span>Consistency: {props.consistent ? "OK" : "Drift"}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
add a Vite-based library build that compiles the new sim/ TypeScript engines into assets/generated/sim-bundle.js, plus a dynamic loader for the existing UI
scaffold the simulator domain (core types/interfaces, polling/trigger/log engines, scenario runner) and provide a TSX metrics stub for the forthcoming React shell
introduce the practitioner harness skeleton (docker-compose stack, generator/verifier services, Debezium connector config, CRUD scenario) and document follow-on work in docs/next-steps.md
Testing

npm run build:sim
