### PR TITLE
Add React-based simulator preview shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A zero-dependency web app that simulates CDC operations and emits Debezium-style
 ## Run locally
 Open `index.html` in a browser. No build step.
 
-### Simulator bundle
+### Build artefacts
 - Install tooling: `npm install`
-- Build the simulator modules: `npm run build:sim`
-
-The build emits `assets/generated/sim-bundle.js`, which `assets/sim-loader.js` loads on demand so the existing UI can access the TypeScript engines.
+- Build simulator engines: `npm run build:sim` → emits `assets/generated/sim-bundle.js` for `assets/sim-loader.js`
+- Build the React preview shell: `npm run build:web` → emits `assets/generated/ui-shell.js` for `assets/ui-shell-loader.js`
+- Build everything: `npm run build`
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).

--- a/assets/ui-shell-loader.js
+++ b/assets/ui-shell-loader.js
@@ -1,0 +1,23 @@
+(function initUiShell(global) {
+  if (global.__LetstalkCdcUiShellLoaded) return;
+
+  async function loadShell() {
+    try {
+      await import("./assets/generated/ui-shell.js");
+      global.__LetstalkCdcUiShellLoaded = true;
+    } catch (error) {
+      console.warn(
+        "Simulator UI shell bundle missing. Run `npm run build:web` to generate assets/generated/ui-shell.js before loading the page.",
+        error
+      );
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      void loadShell();
+    }, { once: true });
+  } else {
+    void loadShell();
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,15 +1,15 @@
 # Implementation Next Steps
 
-_Tooling status: Vite (library mode) builds `sim/bundle.ts` into `assets/generated/sim-bundle.js` via `npm run build:sim`._
+_Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm run build:web` → `assets/generated/ui-shell.js`._
 
 ## Immediate Decisions
-- **Legacy ↔ Vite boundary**: define which parts of `assets/app.js` migrate first and how data flows between vanilla DOM state and the Vite-powered simulator bundle while React work ramps.
+- **Data contract between DOM + React**: decide how the new React shell exchanges schema/row/event data with the legacy controls during the migration window.
 - **State container**: confirm whether we use lightweight emitter only or layer Zustand/RxJS before multi-lane comparator work starts.
-- **React integration strategy**: outline migration path from the current DOM-driven UI to React components, including carve-out plan for coexisting approaches during the transition.
+- **Scenario authoring**: define a single source of truth for built-in scenarios so simulator, harness, and legacy templates stay in sync.
 
 ## Near-Term Build Goals
-1. Wire ScenarioRunner + engines into a thin React shell (served via Vite) that renders a single-lane simulator using stub metrics, then hydrate it into the existing page.
-2. Introduce deterministic clock/tick loop with pause/resume to support guided tour scripting.
+1. Expand the React shell to support multi-lane comparison and shared timeline metrics.
+2. Introduce deterministic clock/tick loop hooks to drive guided tour scripting from the React layer.
 3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
 4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.
 

--- a/index.html
+++ b/index.html
@@ -237,6 +237,13 @@
         </section>
       </div>
     </section>
+
+    <section class="workspace-panel" id="sim-shell-preview" aria-labelledby="simShellTitle">
+      <h2 id="simShellTitle" class="section-title">CDC Method Preview (beta)</h2>
+      <div id="simShellRoot">
+        <p>Preparing simulator preview…</p>
+      </div>
+    </section>
   </main>
 
   <footer class="footer">
@@ -276,5 +283,6 @@
 
   <script src="assets/sim-loader.js"></script>
   <script src="assets/app.js"></script>
+  <script src="assets/ui-shell-loader.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,11 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build:sim": "vite build",
-    "preview:sim": "vite preview",
-    "dev:sim": "vite" 
+    "build": "npm run build:sim && npm run build:web",
+    "build:sim": "vite build --mode sim",
+    "build:web": "vite build --mode web",
+    "dev:sim": "vite --mode sim",
+    "dev:web": "vite --mode web",
+    "preview:sim": "vite preview --mode sim",
+    "preview:web": "vite preview --mode web"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.4.5",
     "vite": "^5.2.9"
   }

--- a/sim/engines/LogEngine.ts
+++ b/sim/engines/LogEngine.ts
@@ -14,6 +14,14 @@ export class LogEngine extends BaseEngine {
     if (opts.fetch_interval_ms !== undefined) this.fetchIntervalMs = opts.fetch_interval_ms;
   }
 
+  reset(seed: number) {
+    super.reset(seed);
+    this.table.clear();
+    this.wal = [];
+    this.lsn = 0;
+    this.lastFetch = 0;
+  }
+
   applySourceOp(op: SourceOp) {
     if (op.op === "insert") {
       this.table.set(op.pk.id, {

--- a/sim/engines/PollingEngine.ts
+++ b/sim/engines/PollingEngine.ts
@@ -14,6 +14,12 @@ export class PollingEngine extends BaseEngine {
     if (opts.include_soft_deletes !== undefined) this.includeSoftDeletes = opts.include_soft_deletes;
   }
 
+  reset(seed: number) {
+    super.reset(seed);
+    this.table.clear();
+    this.lastSync = 0;
+  }
+
   applySourceOp(op: SourceOp) {
     if (op.op === "insert") {
       this.table.set(op.pk.id, {

--- a/sim/engines/TriggerEngine.ts
+++ b/sim/engines/TriggerEngine.ts
@@ -16,6 +16,14 @@ export class TriggerEngine extends BaseEngine {
     if (opts.trigger_overhead_ms !== undefined) this.triggerOverheadMs = opts.trigger_overhead_ms;
   }
 
+  reset(seed: number) {
+    super.reset(seed);
+    this.table.clear();
+    this.audit = [];
+    this.extractOffset = 0;
+    this.lastExtract = 0;
+  }
+
   applySourceOp(op: SourceOp) {
     const commitTs = op.t + this.triggerOverheadMs;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "lib": ["DOM", "ES2020"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -10,9 +11,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": []
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": [
-    "sim/**/*.ts"
+    "sim/**/*.ts",
+    "web/**/*.ts",
+    "web/**/*.tsx"
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,40 @@
 import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  build: {
-    outDir: "assets/generated",
-    emptyOutDir: true,
-    lib: {
-      entry: "sim/bundle.ts",
-      name: "LetsTalkCdcSimulator",
-      formats: ["es"],
-      fileName: () => "sim-bundle.js",
+export default defineConfig(({ mode }) => {
+  if (mode === "web") {
+    return {
+      plugins: [react()],
+      publicDir: false,
+      build: {
+        outDir: "assets/generated",
+        emptyOutDir: false,
+        rollupOptions: {
+          input: "web/main.tsx",
+          output: {
+            entryFileNames: "ui-shell.js",
+            chunkFileNames: "ui-[name].js",
+            assetFileNames: "ui-[name].[ext]",
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    publicDir: false,
+    build: {
+      outDir: "assets/generated",
+      emptyOutDir: false,
+      lib: {
+        entry: "sim/bundle.ts",
+        name: "LetsTalkCdcSimulator",
+        formats: ["es"],
+        fileName: () => "sim-bundle.js",
+      },
+      rollupOptions: {
+        external: [],
+      },
     },
-    rollupOptions: {
-      external: [],
-    },
-  },
+  };
 });

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,0 +1,249 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CdcEvent } from "../sim";
+import { LogEngine, PollingEngine, ScenarioRunner, TriggerEngine } from "../sim";
+import { MetricsStrip } from "./components/MetricsStrip";
+import { SCENARIOS, ShellScenario } from "./scenarios";
+import "./styles/shell.css";
+
+type MethodOption = "polling" | "trigger" | "log";
+
+type Metrics = {
+  lagMs: number;
+  throughput: number;
+  deletesPct: number;
+  orderingOk: boolean;
+  consistent: boolean;
+};
+
+const METHOD_LABELS: Record<MethodOption, string> = {
+  polling: "Polling (Query)",
+  trigger: "Trigger (Audit)",
+  log: "Log (WAL)",
+};
+
+const METHOD_DESCRIPTIONS: Record<MethodOption, string> = {
+  polling: "Periodic scans of source state. Fast to set up, but can miss deletes and rapid updates.",
+  trigger: "Database triggers capture before/after into an audit table. Complete coverage, added write latency.",
+  log: "Streams the transaction log for ordered, low-latency change events with minimal source impact.",
+};
+
+const STEP_MS = 100;
+
+function createEngine(method: MethodOption) {
+  switch (method) {
+    case "polling":
+      return new PollingEngine();
+    case "trigger":
+      return new TriggerEngine();
+    case "log":
+    default:
+      return new LogEngine();
+  }
+}
+
+function computeMetrics(events: CdcEvent[], clock: number, scenario: ShellScenario, method: MethodOption): Metrics {
+  const lastEvent = events.length ? events[events.length - 1] : null;
+  const lagMs = lastEvent ? Math.max(clock - lastEvent.ts_ms, 0) : clock;
+  const throughput = clock > 0 ? events.length / (clock / 1000) : 0;
+
+  const totalDeletes = scenario.ops.filter(op => op.op === "delete").length;
+  const capturedDeletes = events.filter(evt => evt.op === "d").length;
+  const deletesPct = totalDeletes === 0 ? 100 : (capturedDeletes / totalDeletes) * 100;
+
+  const orderingOk = events.every((evt, idx) => {
+    if (idx === 0) return true;
+    const prev = events[idx - 1];
+    return evt.ts_ms >= prev.ts_ms;
+  });
+
+  const consistent = orderingOk && (method === "polling" ? capturedDeletes === totalDeletes : true);
+
+  return {
+    lagMs,
+    throughput,
+    deletesPct,
+    orderingOk,
+    consistent,
+  };
+}
+
+export function App() {
+  const [method, setMethod] = useState<MethodOption>("polling");
+  const [scenarioId, setScenarioId] = useState<string>(SCENARIOS[0].name);
+  const [events, setEvents] = useState<CdcEvent[]>([]);
+  const [clock, setClock] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const scenario = useMemo(() => SCENARIOS.find(s => s.name === scenarioId) ?? SCENARIOS[0], [scenarioId]);
+
+  const runnerRef = useRef<ScenarioRunner | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const stopLoop = useCallback(() => {
+    if (timerRef.current != null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const startLoop = useCallback(() => {
+    stopLoop();
+    timerRef.current = window.setInterval(() => {
+      runnerRef.current?.tick(STEP_MS);
+    }, STEP_MS);
+  }, [stopLoop]);
+
+  useEffect(() => {
+    setEvents([]);
+    setClock(0);
+    setIsPlaying(false);
+
+    stopLoop();
+    unsubscribeRef.current?.();
+
+    const runner = new ScenarioRunner();
+    const engine = createEngine(method);
+    const unsubscribe = engine.onEvent(event => {
+      setEvents(prev => [...prev, event]);
+    });
+
+    runner.attach([engine]);
+    runner.load(scenario);
+    runner.reset(scenario.seed);
+    runner.onTick(now => setClock(now));
+
+    runnerRef.current = runner;
+    unsubscribeRef.current = () => {
+      unsubscribe();
+      unsubscribeRef.current = null;
+    };
+
+    return () => {
+      runner.pause();
+      stopLoop();
+      unsubscribeRef.current?.();
+    };
+  }, [method, scenario, stopLoop]);
+
+  const handleStart = useCallback(() => {
+    const runner = runnerRef.current;
+    if (!runner) return;
+
+    runner.reset(scenario.seed);
+    setEvents([]);
+    setClock(0);
+    runner.start();
+    setIsPlaying(true);
+    startLoop();
+  }, [scenario.seed, startLoop]);
+
+  const handlePause = useCallback(() => {
+    runnerRef.current?.pause();
+    setIsPlaying(false);
+    stopLoop();
+  }, [stopLoop]);
+
+  const handleStep = useCallback(() => {
+    const runner = runnerRef.current;
+    if (!runner) return;
+
+    const wasPlaying = isPlaying;
+    if (!wasPlaying) {
+      runner.start();
+    }
+
+    runner.tick(STEP_MS);
+
+    if (!wasPlaying) {
+      runner.pause();
+    }
+  }, [isPlaying]);
+
+  useEffect(() => () => stopLoop(), [stopLoop]);
+
+  const metrics = computeMetrics(events, clock, scenario, method);
+
+  return (
+    <section className="sim-shell" aria-label="Simulator preview">
+      <header className="sim-shell__header">
+        <div>
+          <h2 className="sim-shell__title">CDC Method Preview</h2>
+          <p className="sim-shell__description">Load a canned scenario and watch Polling, Trigger, or Log-based CDC emit events in real time.</p>
+        </div>
+        <div className="sim-shell__actions" role="group" aria-label="Scenario controls">
+          <select
+            aria-label="Scenario"
+            value={scenarioId}
+            onChange={event => setScenarioId(event.target.value)}
+          >
+            {SCENARIOS.map(option => (
+              <option key={option.name} value={option.name}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <div className="sim-shell__method-tabs" role="group" aria-label="Method selector">
+            {(Object.keys(METHOD_LABELS) as MethodOption[]).map(option => (
+              <button
+                key={option}
+                type="button"
+                className="sim-shell__method-button"
+                aria-pressed={option === method}
+                onClick={() => setMethod(option)}
+              >
+                {METHOD_LABELS[option]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <p className="sim-shell__description" aria-live="polite">
+        <strong>{scenario.label}:</strong> {scenario.description}
+      </p>
+
+      <p className="sim-shell__description" aria-live="polite">{METHOD_DESCRIPTIONS[method]}</p>
+
+      <div className="sim-shell__actions" role="group" aria-label="Playback controls">
+        <button type="button" onClick={handleStart} disabled={isPlaying}>
+          Start
+        </button>
+        <button type="button" onClick={handlePause} disabled={!isPlaying}>
+          Pause
+        </button>
+        <button type="button" onClick={handleStep}>
+          Step +{STEP_MS}ms
+        </button>
+      </div>
+
+      <div className="sim-shell__metrics">
+        <MetricsStrip {...metrics} />
+      </div>
+
+      <ul className="sim-shell__event-list" aria-live="polite">
+        {events.length === 0 ? (
+          <li className="sim-shell__empty">No events yet. Start the simulator to stream the change feed.</li>
+        ) : (
+          events.map(event => (
+            <li key={event.seq} className={`sim-shell__event${event.op === "d" ? " sim-shell__event--delete" : ""}`}>
+              <span className="sim-shell__event-op" data-op={event.op}>
+                {event.op}
+              </span>
+              <span>
+                #{event.seq} · pk={event.pk.id}
+              </span>
+              <span className="sim-shell__event-target">
+                ts={event.ts_ms}ms
+              </span>
+            </li>
+          ))
+        )}
+      </ul>
+
+      <footer className="sim-shell__footer">
+        Scenario clock: {clock}ms · {events.length} events emitted
+      </footer>
+    </section>
+  );
+}

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+
+function mount() {
+  const rootElement = document.getElementById("simShellRoot");
+  if (!rootElement) {
+    console.warn("Simulator UI shell mount point not found (simShellRoot).");
+    return;
+  }
+
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mount, { once: true });
+} else {
+  mount();
+}

--- a/web/scenarios.ts
+++ b/web/scenarios.ts
@@ -1,0 +1,34 @@
+import type { Scenario } from "../sim";
+
+export interface ShellScenario extends Scenario {
+  label: string;
+  description: string;
+}
+
+export const SCENARIOS: ShellScenario[] = [
+  {
+    name: "crud-basic",
+    label: "CRUD Basic",
+    description: "Insert, update, and delete a single customer to highlight delete visibility.",
+    seed: 42,
+    ops: [
+      { t: 100, op: "insert", table: "customers", pk: { id: "1" }, after: { name: "A", email: "a@example.com" } },
+      { t: 400, op: "update", table: "customers", pk: { id: "1" }, after: { name: "A1" } },
+      { t: 700, op: "delete", table: "customers", pk: { id: "1" } },
+    ],
+  },
+  {
+    name: "burst-updates",
+    label: "Burst Updates",
+    description: "Five quick updates to expose lost intermediate writes for polling.",
+    seed: 7,
+    ops: [
+      { t: 100, op: "insert", table: "customers", pk: { id: "200" }, after: { name: "Burst", email: "burst@example.com" } },
+      { t: 150, op: "update", table: "customers", pk: { id: "200" }, after: { name: "Burst-1" } },
+      { t: 180, op: "update", table: "customers", pk: { id: "200" }, after: { name: "Burst-2" } },
+      { t: 210, op: "update", table: "customers", pk: { id: "200" }, after: { name: "Burst-3" } },
+      { t: 240, op: "update", table: "customers", pk: { id: "200" }, after: { name: "Burst-4" } },
+      { t: 600, op: "update", table: "customers", pk: { id: "200" }, after: { name: "Burst-Final" } },
+    ],
+  },
+];

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -1,0 +1,161 @@
+.sim-shell {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 12px 18px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.sim-shell__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sim-shell__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.sim-shell__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sim-shell__actions button,
+.sim-shell__actions select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(51, 65, 85, 0.2);
+  background: #ffffff;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.sim-shell__actions button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sim-shell__metrics {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.sim-shell__event-list {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+}
+
+.sim-shell__event {
+  display: grid;
+  grid-template-columns: 70px 1fr 120px;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.85rem;
+}
+
+.sim-shell__event:last-child {
+  border-bottom: none;
+}
+
+.sim-shell__event--delete {
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.sim-shell__event-op {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sim-shell__event-op[data-op="c"] {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.sim-shell__event-op[data-op="u"] {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.sim-shell__event-op[data-op="d"] {
+  background: rgba(220, 38, 38, 0.15);
+  color: #b91c1c;
+}
+
+.sim-shell__description {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+.sim-shell__empty {
+  padding: 1rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+.sim-shell__method-tabs {
+  display: inline-flex;
+  gap: 0.25rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.25rem;
+}
+
+.sim-shell__method-button {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: #1f2937;
+}
+
+.sim-shell__method-button[aria-pressed="true"] {
+  background: #1f2937;
+  color: #ffffff;
+}
+
+.sim-shell__footer {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (max-width: 768px) {
+  .sim-shell {
+    padding: 1rem;
+  }
+
+  .sim-shell__event {
+    grid-template-columns: 60px 1fr;
+  }
+
+  .sim-shell__event-target {
+    display: none;
+  }
+}


### PR DESCRIPTION
**Title:** Add React simulator preview shell and tooling updates

**Summary**
- add a React-based single-lane simulator preview that streams events via `ScenarioRunner`
- surface canned scenarios + method toggles with live metrics to highlight polling/trigger/log behaviour
- extend tooling (Vite/TypeScript/scripts) and docs so both the simulator library and UI shell can be built and loaded dynamically
- harden engine reset behaviour to clear in-memory state between runs

**Testing**
- npm run build:sim
- npm run build:web
