### PR TITLE
Add advanced tuning controls to comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Open `index.html` in a browser. No build step.
 
 The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines in parallel to visualise lag, ordering, and delete capture differences.
 
+### Advanced controls
+- Polling: `poll_interval_ms` knob plus optional soft-delete visibility
+- Trigger: extractor cadence and per-write trigger overhead
+- Log: WAL/Binlog fetch interval
+
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).
 - Browse open issues labeled `hacktoberfest`, `good first issue`, or `help wanted` to find a place to jump in.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,14 +1,15 @@
 # Implementation Next Steps
 
-_Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm run build:web` → `assets/generated/ui-shell.js`. React comparator now renders multi-lane polling/trigger/log preview._
+_Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm run build:web` → `assets/generated/ui-shell.js`. React comparator now renders multi-lane polling/trigger/log preview with tunable method controls._
 
 ## Immediate Decisions
 - **Legacy ↔ React data sync**: decide how schema/table edits from `assets/app.js` feed the comparator (shared store vs. message bus).
+- **Persisting control state**: determine how method tuning persists across reloads and exports (localStorage, scenario metadata, or query params).
 - **State container**: confirm whether we stay with lightweight emitters or introduce Zustand/RxJS before guided tour scripting.
 - **Scenario source of truth**: converge scenario definitions (legacy templates, React comparator, harness) on one module to prevent drift.
 
 ## Near-Term Build Goals
-1. Drive the comparator from live schema/table state (not canned scenarios) and surface diffs back to the legacy UI.
+1. Drive the comparator from live schema/table state (not canned scenarios), keeping advanced controls in sync with export/import flows.
 2. Introduce deterministic clock hooks that power the guided onboarding/tour flow across lanes.
 3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
 4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -100,6 +100,59 @@
   color: #ffffff;
 }
 
+.sim-shell__controls {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.sim-shell__control-card {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: rgba(248, 250, 252, 0.85);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.sim-shell__control-card[data-active="false"] {
+  opacity: 0.55;
+}
+
+.sim-shell__control-card legend {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.sim-shell__control-copy {
+  margin: 0;
+  color: #475569;
+  font-size: 0.85rem;
+}
+
+.sim-shell__control-field {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.sim-shell__control-field input {
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #ffffff;
+  font-size: 0.9rem;
+}
+
+.sim-shell__control-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
 .sim-shell__lane-grid {
   display: grid;
   gap: 1rem;
@@ -149,6 +202,31 @@
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 0.95rem;
   color: #1f2937;
+}
+
+.sim-shell__lane-config {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.4rem 0.75rem;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.sim-shell__lane-config div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.sim-shell__lane-config dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #1f2937;
+}
+
+.sim-shell__lane-config dd {
+  margin: 0;
 }
 
 .sim-shell__callout {


### PR DESCRIPTION
**Title:** Add advanced tuning controls to CDC comparator shell

**Summary**
- introduce per-method tuning (poll interval & soft deletes for polling, extractor cadence & trigger overhead for trigger, fetch interval for log) with configurable UI panels
- feed the new settings into engine configuration before playback and surface the active values in each lane card
- document the controls and capture next integration steps around persisting/tethering them to the legacy experience

**Testing**
- npm run build:sim *(fails: missing @vitejs/plugin-react until npm install runs)*
- npm run build:web
