### PR TITLE
Bridge workspace data into simulator comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines i
 - Polling: `poll_interval_ms` knob plus optional soft-delete visibility
 - Trigger: extractor cadence and per-write trigger overhead
 - Log: WAL/Binlog fetch interval
+- Live workspace feed: the comparator listens for table mutations and exposes them as a "Workspace (live)" scenario alongside curated demos
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -3,13 +3,13 @@
 _Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm run build:web` → `assets/generated/ui-shell.js`. React comparator now renders multi-lane polling/trigger/log preview with tunable method controls._
 
 ## Immediate Decisions
-- **Legacy ↔ React data sync**: decide how schema/table edits from `assets/app.js` feed the comparator (shared store vs. message bus).
+- **Legacy ↔ React feedback loop**: now that the comparator consumes workspace state, decide how comparator insights flow back to the vanilla UI (callouts, filters, guided tips).
 - **Persisting control state**: determine how method tuning persists across reloads and exports (localStorage, scenario metadata, or query params).
 - **State container**: confirm whether we stay with lightweight emitters or introduce Zustand/RxJS before guided tour scripting.
 - **Scenario source of truth**: converge scenario definitions (legacy templates, React comparator, harness) on one module to prevent drift.
 
 ## Near-Term Build Goals
-1. Drive the comparator from live schema/table state (not canned scenarios), keeping advanced controls in sync with export/import flows.
+1. Persist workspace scenarios + advanced controls into export/import/share flows and expose comparator metrics back to the DOM UI.
 2. Introduce deterministic clock hooks that power the guided onboarding/tour flow across lanes.
 3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
 4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.


### PR DESCRIPTION
**Title:** Bridge workspace data into simulator comparator

**Summary**
- dispatch live workspace schema/row/event snapshots from the legacy app so the comparator can consume real user activity
- teach the React comparator to register a “Workspace (live)” scenario, merge it with canned demos, and auto-select it when fresh ops arrive
- document the live feed capability and update implementation notes around persisting controls and feeding insights back to the DOM UI

**Testing**
- npm run build:sim
- npm run build:web
