### PR TITLE
Persist comparator scenario and control preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines i
 - Trigger: extractor cadence and per-write trigger overhead
 - Log: WAL/Binlog fetch interval
 - Live workspace feed: the comparator listens for table mutations and exposes them as a "Workspace (live)" scenario alongside curated demos
+- Comparator preferences (scenario, methods, knobs) persist locally so you resume where you left off
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).


### PR DESCRIPTION
Comparator Persistence

web/App.tsx:1 now loads/saves comparator preferences (scenario selection, active methods, tuning knobs, user pin) in localStorage, sanitizes them on boot, and restores them alongside the live “Workspace (live)” feed so the React shell resumes exactly where you left off.
assets/app.js:805 already broadcasts workspace changes; the comparator now auto-selects the live scenario only when the user hasn’t pinned something else and reverts gracefully when the feed disappears.
README.md:16 notes that comparator scenarios/controls persist locally; docs/next-steps.md:1 reframes follow-up work around surfacing comparator insights back into the legacy UI.
Tests

npm run build:sim
npm run build:web