### PR TITLE
Surface comparator insights in legacy workspace

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1001,6 +1001,52 @@ code {
 }
 .filter-actions label { display: inline-flex; align-items: center; gap: 6px; }
 
+.comparator-feedback {
+  margin: 12px 0;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 196, 0.35);
+  background: rgba(24, 36, 64, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  color: var(--muted-strong);
+  display: grid;
+  gap: 8px;
+}
+
+.comparator-feedback[data-live="true"] {
+  border-color: rgba(59, 130, 246, 0.55);
+  background: rgba(37, 99, 235, 0.16);
+  color: #dbeafe;
+}
+
+.comparator-feedback__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.comparator-feedback__meta {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.comparator-feedback ul {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.comparator-feedback strong {
+  color: var(--ink);
+}
+
 .sparkle {
   position: fixed;
   width: 8px;

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -3,13 +3,13 @@
 _Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm run build:web` → `assets/generated/ui-shell.js`. React comparator now renders multi-lane polling/trigger/log preview with tunable method controls._
 
 ## Immediate Decisions
-- **Legacy ↔ React feedback loop**: now that the comparator consumes workspace state, decide how comparator insights flow back to the vanilla UI (callouts, filters, guided tips).
-- **Persisting control state**: determine how method tuning persists across reloads and exports (localStorage, scenario metadata, or query params).
+- **Guided insight UX**: decide how comparator callouts integrate with onboarding/tooltips now that insights surface in the legacy UI.
+- **Persisting control state**: determine how method tuning persists across exports/shares (extend payload schema vs. runtime defaults).
 - **State container**: confirm whether we stay with lightweight emitters or introduce Zustand/RxJS before guided tour scripting.
 - **Scenario source of truth**: converge scenario definitions (legacy templates, React comparator, harness) on one module to prevent drift.
 
 ## Near-Term Build Goals
-1. Persist workspace scenarios + advanced controls into export/import/share flows and expose comparator metrics back to the DOM UI.
+1. Persist workspace scenarios + advanced controls into export/import/share flows, including comparator insight snapshots.
 2. Introduce deterministic clock hooks that power the guided onboarding/tour flow across lanes.
 3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
 4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.

--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
             <button id="btnCopyNdjson" type="button">Copy NDJSON</button>
             <button id="btnDownloadNdjson" type="button">Download NDJSON</button>
           </div>
+          <div id="comparatorFeedback" class="comparator-feedback" hidden aria-live="polite"></div>
           <pre id="eventLog" class="log"></pre>
           <section class="inspector" id="eventInspector" aria-labelledby="inspectorTitle">
             <div class="inspector-header">


### PR DESCRIPTION
Added a comparator insight panel to the legacy change-feed card (index.html:219, assets/styles.css:1004) so the vanilla UI now surfaces lag, delete coverage, and ordering callouts coming from the React shell.
Broadcast comparator summaries from React via cdc:comparator-summary, bundling labeled lane metrics and summary stats (web/App.tsx:371), and taught the legacy app to listen/respond with rich copy plus live/offline styling (assets/app.js:943).
Updated implementation notes to focus on wiring these insights into onboarding/share flows next (docs/next-steps.md:5) and captured the behaviour in README (README.md:16).
Tests

npm run build:sim
npm run build:web
