### PR TITLE
Include comparator state in exports and shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines i
 - Log: WAL/Binlog fetch interval
 - Live workspace feed: the comparator listens for table mutations and exposes them as a "Workspace (live)" scenario alongside curated demos
 - Comparator preferences (scenario, methods, knobs) persist locally so you resume where you left off
+- Exports/imports carry comparator preferences and the latest insight snapshot for consistent replays
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -360,6 +360,39 @@ export function App() {
   }, [liveScenario]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handler = (event: Event) => {
+      const prefs = (event as CustomEvent<ComparatorPreferences | null>).detail;
+      if (!prefs) {
+        userSelectedScenarioRef.current = false;
+        return;
+      }
+
+      if (prefs.userPinnedScenario != null) {
+        userSelectedScenarioRef.current = Boolean(prefs.userPinnedScenario);
+      }
+
+      if (prefs.activeMethods) {
+        setActiveMethods(sanitizeActiveMethods(prefs.activeMethods));
+      }
+
+      if (prefs.methodConfig) {
+        setMethodConfig(sanitizeMethodConfig(prefs.methodConfig));
+      }
+
+      if (prefs.scenarioId) {
+        setScenarioId(prefs.scenarioId);
+      }
+    };
+
+    window.addEventListener("cdc:comparator-preferences-set", handler as EventListener);
+    return () => {
+      window.removeEventListener("cdc:comparator-preferences-set", handler as EventListener);
+    };
+  }, []);
+
+  useEffect(() => {
     savePreferences({
       scenarioId,
       activeMethods,


### PR DESCRIPTION
Export/import/share flows now capture comparator preferences and the latest insight snapshot (assets/app.js:595, assets/app.js:1755), and hydrate them on import so the React shell resumes the same scenario/tuning (web/App.tsx:362).
Legacy UI listens for comparator summaries and renders persistence-aware callouts; those summaries are cached for exports, and preferences can now be set from import/share payloads via a new event bridge (assets/app.js:943, web/App.tsx:371).
README notes that exports carry comparator metadata, keeping shared scenarios “technically honest” out of the box (README.md:16).
Tests

npm run build:sim
npm run build:web
