### PR TITLE
Allow comparator to load scenarios into workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines i
 - Comparator preferences (scenario, methods, knobs) persist locally so you resume where you left off
 - Exports/imports carry comparator preferences and the latest insight snapshot for consistent replays
 - Curated scenarios live in `assets/shared-scenarios.js`; update that module once to change both the template gallery and comparator demos
+- Comparator lets you push any scenario back into the workspace via the new “Load in workspace” shortcut
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).

--- a/assets/app.js
+++ b/assets/app.js
@@ -852,6 +852,14 @@ if (typeof window !== "undefined") {
   window.addEventListener("cdc:comparator-summary", (event) => {
     renderComparatorFeedback(event?.detail);
   });
+  window.addEventListener("cdc:apply-scenario-template", (event) => {
+    const templateId = event?.detail?.id;
+    if (!templateId) return;
+    const template = getTemplateById(templateId);
+    if (template) {
+      applyScenarioTemplate(template, { focusStep: "events" });
+    }
+  });
 }
 
 function renderComparatorFeedback(detail) {

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -616,7 +616,7 @@ export function App() {
             Load a deterministic scenario and contrast Polling, Trigger, and Log-based CDC side by side.
           </p>
         </div>
-        <div className="sim-shell__actions" role="group" aria-label="Scenario controls">
+        <div className="sim-shell__actions sim-shell__actions--scenario" role="group" aria-label="Scenario controls">
           <select
             aria-label="Scenario"
             value={scenarioId}
@@ -628,6 +628,21 @@ export function App() {
               </option>
             ))}
           </select>
+          <button
+            type="button"
+            className="sim-shell__scenario-sync"
+            onClick={() => {
+              if (scenario.name === LIVE_SCENARIO_NAME) return;
+              window.dispatchEvent(
+                new CustomEvent("cdc:apply-scenario-template", {
+                  detail: { id: scenario.name },
+                }),
+              );
+            }}
+            disabled={scenario.name === LIVE_SCENARIO_NAME}
+          >
+            Load in workspace
+          </button>
           <div className="sim-shell__method-toggle" role="group" aria-label="Methods to display">
             {METHOD_ORDER.map(method => (
               <button
@@ -647,6 +662,11 @@ export function App() {
       <p className="sim-shell__description" aria-live="polite">
         <strong>{scenario.label}:</strong> {scenario.description}
       </p>
+      {scenario.highlight && (
+        <p className="sim-shell__description sim-shell__description--highlight" aria-live="polite">
+          {scenario.highlight}
+        </p>
+      )}
 
       <div className="sim-shell__actions" role="group" aria-label="Playback controls">
         <button type="button" onClick={handleStart} disabled={isPlaying}>

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -57,6 +57,11 @@
   font-size: 0.95rem;
 }
 
+.sim-shell__description--highlight {
+  color: #1d4ed8;
+  font-style: italic;
+}
+
 .sim-shell__summary {
   margin: 0;
   padding: 1rem 1.25rem;
@@ -98,6 +103,30 @@
 .sim-shell__method-chip[aria-pressed="true"] {
   background: #1f2937;
   color: #ffffff;
+}
+
+.sim-shell__actions--scenario {
+  gap: 0.5rem;
+}
+
+.sim-shell__scenario-sync {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sim-shell__scenario-sync:hover:not([disabled]) {
+  background: rgba(37, 99, 235, 0.2);
+  color: #1e3a8a;
+}
+
+.sim-shell__scenario-sync[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .sim-shell__controls {


### PR DESCRIPTION
Added a shared scenario module (assets/shared-scenarios.js) that seeds both the template gallery and comparator; scenarios now include normalized ops, schema, rows, and highlight text.
Comparator imports the shared list (web/scenarios.ts:1), derives ops from events if needed, surfaces highlights, and exposes a “Load in workspace” button to dispatch cdc:apply-scenario-template.
Legacy app listens for that event, reusing applyScenarioTemplate to hydrate the workspace (assets/app.js:1005), keeping UI in sync. Updated comparator styling and README to reflect the new shared source and workspace shortcut (web/styles/shell.css:1, README.md:16).
Tests: npm run build:sim, npm run build:web.

