### PR TITLE
Deliver near-term comparator roadmap goals

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,22 @@
+name: Preflight Checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run preflight suite
+        run: npm run ci:preflight

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Open `index.html` in a browser. No build step.
 - Build the React comparator shell: `npm run build:web` → emits `assets/generated/ui-shell.js` for `assets/ui-shell-loader.js`
 - Build everything: `npm run build`
 
+### Verification
+- Property-based invariants: `npm run test:sim` (requires a fresh `npm run build:sim` bundle)
+- Full preflight mirror: `npm run ci:preflight` (runs sim/web builds and the invariant suite—identical to the GitHub Actions workflow)
+
 The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines in parallel to visualise lag, ordering, and delete capture differences.
 
 ### Advanced controls
@@ -22,6 +26,7 @@ The comparator mount (`#simShellRoot`) streams the Polling/Trigger/Log engines i
 - Exports/imports carry comparator preferences and the latest insight snapshot for consistent replays
 - Curated scenarios live in `assets/shared-scenarios.js`; update that module once to change both the template gallery and comparator demos
 - Comparator lets you push any scenario back into the workspace via the new “Load in workspace” shortcut
+- Lane diff overlays surface missing/extra/out-of-order operations and lag hotspots per method so insights link to exact events
 
 ## Hacktoberfest 2025
 - This repository is registered for Hacktoberfest 2025. Make sure you have signed up at [hacktoberfest.com](https://hacktoberfest.com/).

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -10,12 +10,12 @@ _Tooling status: `npm run build:sim` → `assets/generated/sim-bundle.js`, `npm 
 - **Feature flag posture** _(Decision: launch behind `comparator_v2`)_ → Ship comparator enhancements gated via runtime flag with staged rollout (internal → beta → GA). Action: implement flag hook in shell bootstrap and draft the rollout calendar captured in Launch Readiness.
 
 ## Near-Term Build Goals
-1. Persist workspace scenarios + advanced controls into export/import/share flows, including comparator insight snapshots.
-2. Introduce deterministic clock hooks that power the guided onboarding/tour flow across lanes.
-3. Implement property-based tests for Polling/Trigger/Log invariants (lag behaviour, delete visibility, ordering).
-4. Freeze Scenario JSON schema for export/import and ensure existing templates or seeds map cleanly onto it.
-5. Ship lane diff overlays inside the comparator so insight callouts can link to concrete event deltas.
-6. Stand up a preflight lint/type/test suite in CI that mirrors the manual `sim` + `web` build to catch regressions before packaging.
+1. ✅ Persist workspace scenarios + advanced controls into export/import/share flows—exports now carry comparator preferences, analytics, and lane diffs; import/share hydration applies them and snapshots render inside the legacy shell.
+2. ✅ Introduce deterministic clock hooks—`window.cdcComparatorClock` and `cdc:comparator-clock` events allow guided tours to play, pause, step, seek, and reset the React comparator on a deterministic timeline.
+3. ✅ Implement property-based tests (`npm run test:sim`) covering lag, delete capture, and ordering invariants across Polling/Trigger/Log engines using randomly generated scenarios.
+4. ✅ Freeze Scenario JSON schema at `docs/schema/scenario-v2.json`, locking the v2 payload contract and verifying shared templates conform.
+5. ✅ Ship lane diff overlays in the comparator so insight callouts surface concrete missing/extra/order issues and lag hotspots per method.
+6. ✅ Stand up a preflight suite (`npm run ci:preflight`) mirrored in GitHub Actions to run sim/web builds plus property tests before packaging.
 
 ## Harness Track
 - Flesh out generator/verifier packages with scripts to pull the shared scenario JSON and emit PASS/FAIL.

--- a/docs/schema/scenario-v2.json
+++ b/docs/schema/scenario-v2.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CDC Scenario Payload v2",
+  "description": "Frozen schema for exported/imported CDC playground scenarios and comparator snapshots.",
+  "type": "object",
+  "required": ["version", "schema", "rows", "events"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 2
+    },
+    "exported_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "schema": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "pk": { "type": "boolean" },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "rows": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["op", "pk"],
+        "properties": {
+          "source": { "type": "string" },
+          "table": { "type": "string" },
+          "op": { "type": "string", "enum": ["c", "u", "d", "r"] },
+          "pk": { "type": "object" },
+          "before": { "type": ["object", "null"] },
+          "after": { "type": ["object", "null"] },
+          "ts_ms": { "type": ["number", "integer"] },
+          "tx": { "type": "object" },
+          "seq": { "type": "integer" },
+          "meta": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "scenarioId": { "type": ["string", "null"] },
+    "remoteId": { "type": ["string", "null"] },
+    "comparator": {
+      "type": "object",
+      "properties": {
+        "preferences": { "type": ["object", "null"] },
+        "summary": { "type": ["object", "null"] },
+        "analytics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "method": { "type": "string" },
+              "label": { "type": "string" },
+              "total": { "type": "integer" },
+              "inserts": { "type": "integer" },
+              "updates": { "type": "integer" },
+              "deletes": { "type": "integer" }
+            },
+            "additionalProperties": true
+          }
+        },
+        "diffs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "method": { "type": "string" },
+              "totals": {
+                "type": "object",
+                "properties": {
+                  "missing": { "type": "integer" },
+                  "extra": { "type": "integer" },
+                  "ordering": { "type": "integer" }
+                },
+                "additionalProperties": false
+              },
+              "issues": {
+                "type": "array",
+                "items": { "type": "object" }
+              },
+              "lag": {
+                "type": "object",
+                "properties": {
+                  "max": { "type": "number" },
+                  "samples": {
+                    "type": "array",
+                    "items": { "type": "object" }
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "dev:sim": "vite --mode sim",
     "dev:web": "vite --mode web",
     "preview:sim": "vite preview --mode sim",
-    "preview:web": "vite preview --mode web"
+    "preview:web": "vite preview --mode web",
+    "test:sim": "node sim/tests/property-tests.mjs",
+    "ci:preflight": "npm run build:sim && npm run build:web && npm run test:sim"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/sim/analysis/diff.ts
+++ b/sim/analysis/diff.ts
@@ -1,0 +1,254 @@
+import type { CdcEvent, SourceOp } from "../core/types";
+
+const EVENT_OPS = new Set(["c", "u", "d"] as const);
+
+type EventOp = "c" | "u" | "d";
+
+export type LaneDiffIssueType = "missing" | "extra" | "ordering";
+
+export type LaneDiffIssue = {
+  type: LaneDiffIssueType;
+  op: EventOp;
+  pk: string;
+  expectedIndex?: number;
+  actualIndex?: number;
+  expectedTime?: number;
+  actualTime?: number;
+  lagMs?: number;
+};
+
+export type LaneLagSample = {
+  op: EventOp;
+  pk: string;
+  expectedTime: number;
+  actualTime: number;
+  lagMs: number;
+};
+
+export type LaneDiffResult = {
+  method: string;
+  totals: {
+    missing: number;
+    extra: number;
+    ordering: number;
+  };
+  issues: LaneDiffIssue[];
+  lag: {
+    max: number;
+    samples: LaneLagSample[];
+  };
+};
+
+type ExpectedEntry = {
+  key: string;
+  op: EventOp;
+  pk: string;
+  index: number;
+  time: number;
+};
+
+type ActualEntry = {
+  key: string;
+  op: EventOp;
+  pk: string;
+  index: number;
+  time: number;
+};
+
+type MatchedPair = {
+  expected: ExpectedEntry;
+  actual: ActualEntry;
+  lagMs: number;
+};
+
+function mapSourceOp(op: SourceOp): EventOp | null {
+  switch (op.op) {
+    case "insert":
+      return "c";
+    case "update":
+      return "u";
+    case "delete":
+      return "d";
+    default:
+      return null;
+  }
+}
+
+function buildExpectedEntries(sourceOps: SourceOp[]): ExpectedEntry[] {
+  return sourceOps
+    .map((op, index) => {
+      const opCode = mapSourceOp(op);
+      if (!opCode) return null;
+      const pk = op.pk?.id != null ? String(op.pk.id) : "";
+      return {
+        key: `${opCode}::${pk}`,
+        op: opCode,
+        pk,
+        index,
+        time: op.t,
+      };
+    })
+    .filter((entry): entry is ExpectedEntry => Boolean(entry));
+}
+
+function buildActualEntries(events: CdcEvent[]): ActualEntry[] {
+  return events
+    .map((event, index) => {
+      if (!EVENT_OPS.has(event.op as EventOp)) return null;
+      const pk = event.pk?.id != null ? String(event.pk.id) : "";
+      const op = event.op as EventOp;
+      return {
+        key: `${op}::${pk}`,
+        op,
+        pk,
+        index,
+        time: event.ts_ms,
+      };
+    })
+    .filter((entry): entry is ActualEntry => Boolean(entry));
+}
+
+function toBuckets<T extends { key: string }>(entries: T[]): Map<string, T[]> {
+  const buckets = new Map<string, T[]>();
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.key);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      buckets.set(entry.key, [entry]);
+    }
+  }
+  return buckets;
+}
+
+function matchEntries(expected: ExpectedEntry[], actual: ActualEntry[]): {
+  matched: MatchedPair[];
+  missing: ExpectedEntry[];
+  extra: ActualEntry[];
+} {
+  const matched: MatchedPair[] = [];
+  const missing: ExpectedEntry[] = [];
+  const extra: ActualEntry[] = [];
+
+  const expectedBuckets = toBuckets(expected);
+  const actualBuckets = toBuckets(actual);
+  const keys = new Set<string>([...expectedBuckets.keys(), ...actualBuckets.keys()]);
+
+  for (const key of keys) {
+    const expectedList = expectedBuckets.get(key) ?? [];
+    const actualList = actualBuckets.get(key) ?? [];
+    const pairCount = Math.min(expectedList.length, actualList.length);
+
+    for (let i = 0; i < pairCount; i++) {
+      const exp = expectedList[i];
+      const act = actualList[i];
+      matched.push({
+        expected: exp,
+        actual: act,
+        lagMs: Math.max(0, act.time - exp.time),
+      });
+    }
+
+    for (let i = pairCount; i < expectedList.length; i++) {
+      missing.push(expectedList[i]);
+    }
+
+    for (let i = pairCount; i < actualList.length; i++) {
+      extra.push(actualList[i]);
+    }
+  }
+
+  return { matched, missing, extra };
+}
+
+function detectOrderingIssues(matched: MatchedPair[]): LaneDiffIssue[] {
+  const issues: LaneDiffIssue[] = [];
+  const ordered = [...matched].sort((a, b) => a.actual.index - b.actual.index);
+  let lastExpectedIndex = -Infinity;
+
+  for (const pair of ordered) {
+    if (pair.expected.index < lastExpectedIndex) {
+      issues.push({
+        type: "ordering",
+        op: pair.expected.op,
+        pk: pair.expected.pk,
+        expectedIndex: pair.expected.index,
+        actualIndex: pair.actual.index,
+        expectedTime: pair.expected.time,
+        actualTime: pair.actual.time,
+      });
+    } else {
+      lastExpectedIndex = pair.expected.index;
+    }
+  }
+
+  return issues;
+}
+
+function buildLagSamples(matched: MatchedPair[]): LaneLagSample[] {
+  return matched
+    .filter(pair => pair.lagMs > 0)
+    .sort((a, b) => b.lagMs - a.lagMs)
+    .slice(0, 5)
+    .map(pair => ({
+      op: pair.expected.op,
+      pk: pair.expected.pk,
+      expectedTime: pair.expected.time,
+      actualTime: pair.actual.time,
+      lagMs: pair.lagMs,
+    }));
+}
+
+export function diffLane(method: string, scenarioOps: SourceOp[], events: CdcEvent[]): LaneDiffResult {
+  const expectedEntries = buildExpectedEntries(scenarioOps);
+  const actualEntries = buildActualEntries(events);
+  const { matched, missing, extra } = matchEntries(expectedEntries, actualEntries);
+
+  const issues: LaneDiffIssue[] = [];
+
+  for (const miss of missing) {
+    issues.push({
+      type: "missing",
+      op: miss.op,
+      pk: miss.pk,
+      expectedIndex: miss.index,
+      expectedTime: miss.time,
+    });
+  }
+
+  for (const surplus of extra) {
+    issues.push({
+      type: "extra",
+      op: surplus.op,
+      pk: surplus.pk,
+      actualIndex: surplus.index,
+      actualTime: surplus.time,
+    });
+  }
+
+  issues.push(...detectOrderingIssues(matched));
+
+  const lagSamples = buildLagSamples(matched);
+  const maxLag = lagSamples.reduce((max, sample) => Math.max(max, sample.lagMs), 0);
+
+  return {
+    method,
+    totals: {
+      missing: issues.filter(issue => issue.type === "missing").length,
+      extra: issues.filter(issue => issue.type === "extra").length,
+      ordering: issues.filter(issue => issue.type === "ordering").length,
+    },
+    issues,
+    lag: {
+      max: maxLag,
+      samples: lagSamples,
+    },
+  };
+}
+
+export function diffAllLanes(
+  scenarioOps: SourceOp[],
+  lanes: Array<{ method: string; events: CdcEvent[] }>,
+): LaneDiffResult[] {
+  return lanes.map(lane => diffLane(lane.method, scenarioOps, lane.events));
+}

--- a/sim/bundle.ts
+++ b/sim/bundle.ts
@@ -5,6 +5,8 @@ import {
   LogEngine,
   ScenarioRunner,
 } from "./index";
+import { diffLane, diffAllLanes } from "./analysis/diff";
+import type { LaneDiffResult, LaneDiffIssue, LaneDiffIssueType, LaneLagSample } from "./analysis/diff";
 import type {
   CdcEvent,
   SourceOp,
@@ -24,6 +26,8 @@ const exportsObject = {
   TriggerEngine,
   LogEngine,
   ScenarioRunner,
+  diffLane,
+  diffAllLanes,
 };
 
 // Attach for non-module consumers once the bundle loads.
@@ -40,8 +44,20 @@ export type {
   MethodEngine,
   Scenario,
   ScenarioRunnerApi,
+  LaneDiffResult,
+  LaneDiffIssue,
+  LaneDiffIssueType,
+  LaneLagSample,
 };
 
-export { EventBus, PollingEngine, TriggerEngine, LogEngine, ScenarioRunner };
+export {
+  EventBus,
+  PollingEngine,
+  TriggerEngine,
+  LogEngine,
+  ScenarioRunner,
+  diffLane,
+  diffAllLanes,
+};
 
 export default exportsObject;

--- a/sim/index.ts
+++ b/sim/index.ts
@@ -5,3 +5,5 @@ export { PollingEngine } from "./engines/PollingEngine";
 export { TriggerEngine } from "./engines/TriggerEngine";
 export { LogEngine } from "./engines/LogEngine";
 export { ScenarioRunner } from "./scenario/ScenarioRunner";
+export { diffLane, diffAllLanes } from "./analysis/diff";
+export type { LaneDiffResult, LaneDiffIssue, LaneDiffIssueType, LaneLagSample } from "./analysis/diff";

--- a/sim/tests/property-tests.mjs
+++ b/sim/tests/property-tests.mjs
@@ -1,0 +1,234 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const bundlePath = path.resolve(__dirname, '../../assets/generated/sim-bundle.js');
+
+if (!fs.existsSync(bundlePath)) {
+  console.error('[property-tests] Build artefact missing. Run `npm run build:sim` before `npm run test:sim`.');
+  process.exit(1);
+}
+
+const bundle = await import(pathToFileURL(bundlePath));
+
+const {
+  ScenarioRunner,
+  PollingEngine,
+  TriggerEngine,
+  LogEngine,
+  diffLane,
+} = bundle;
+
+if (!ScenarioRunner || !PollingEngine || !TriggerEngine || !LogEngine || !diffLane) {
+  console.error('[property-tests] Simulator bundle missing expected exports. Rebuild the sim artefact.');
+  process.exit(1);
+}
+
+function createRng(seed) {
+  let state = seed % 2147483647;
+  if (state <= 0) state += 2147483646;
+  return () => {
+    state = (state * 16807) % 2147483647;
+    return (state - 1) / 2147483646;
+  };
+}
+
+function pick(list, rng) {
+  const index = Math.floor(rng() * list.length);
+  return list[index];
+}
+
+function generateRow(id, rng) {
+  const customers = ['Acme', 'Globex', 'Initech', 'Umbra', 'Soylent'];
+  const statuses = ['pending', 'processing', 'complete', 'cancelled'];
+  return {
+    id,
+    customer: pick(customers, rng),
+    status: pick(statuses, rng),
+    amount: Number((rng() * 1000).toFixed(2)),
+  };
+}
+
+function generateScenario(seed) {
+  const rng = createRng(seed * 97);
+  const ops = [];
+  const active = new Map();
+  let t = 0;
+  let nextId = 1;
+  const totalOps = Math.floor(rng() * 12) + 6; // 6-17 operations
+
+  const stepTime = () => {
+    t += Math.floor(rng() * 220) + 40;
+    return t;
+  };
+
+  for (let i = 0; i < totalOps; i++) {
+    let opType = 'insert';
+    const activeIds = [...active.keys()];
+    if (activeIds.length > 0) {
+      const roll = rng();
+      if (roll < 0.45) opType = 'insert';
+      else if (roll < 0.8) opType = 'update';
+      else opType = 'delete';
+    }
+
+    if (opType === 'insert' || active.size === 0) {
+      const id = `R-${seed}-${nextId++}`;
+      const row = generateRow(id, rng);
+      active.set(id, row);
+      ops.push({
+        t: stepTime(),
+        op: 'insert',
+        table: 'customers',
+        pk: { id },
+        after: row,
+      });
+    } else if (opType === 'update') {
+      const id = pick(activeIds, rng);
+      const current = active.get(id) || generateRow(id, rng);
+      const patch = {
+        status: rng() > 0.5 ? pick(['pending', 'processing', 'complete', 'cancelled'], rng) : current.status,
+        amount: Number((current.amount + (rng() - 0.5) * 120).toFixed(2)),
+      };
+      const next = { ...current, ...patch };
+      active.set(id, next);
+      ops.push({
+        t: stepTime(),
+        op: 'update',
+        table: 'customers',
+        pk: { id },
+        after: patch,
+      });
+    } else if (opType === 'delete') {
+      const id = pick(activeIds, rng);
+      active.delete(id);
+      ops.push({
+        t: stepTime(),
+        op: 'delete',
+        table: 'customers',
+        pk: { id },
+      });
+    }
+  }
+
+  if (!ops.some(op => op.op === 'delete') && active.size > 0) {
+    const [id] = active.keys();
+    active.delete(id);
+    ops.push({
+      t: stepTime(),
+      op: 'delete',
+      table: 'customers',
+      pk: { id },
+    });
+  }
+
+  return {
+    name: `property-${seed}`,
+    seed,
+    ops,
+  };
+}
+
+function runScenario(scenario) {
+  const runner = new ScenarioRunner();
+  const polling = new PollingEngine();
+  const trigger = new TriggerEngine();
+  const log = new LogEngine();
+
+  polling.configure({ poll_interval_ms: 200, include_soft_deletes: true });
+  trigger.configure({ extract_interval_ms: 150, trigger_overhead_ms: 6 });
+  log.configure({ fetch_interval_ms: 25 });
+
+  const lanes = new Map([
+    ['polling', { engine: polling, events: [] }],
+    ['trigger', { engine: trigger, events: [] }],
+    ['log', { engine: log, events: [] }],
+  ]);
+
+  lanes.forEach(({ engine, events }) => {
+    engine.onEvent(evt => events.push(evt));
+  });
+
+  runner.attach([...lanes.values()].map(item => item.engine));
+  runner.load(scenario);
+  runner.reset(scenario.seed);
+  runner.onTick(() => {});
+  runner.start();
+
+  const lastOpTime = scenario.ops.length ? scenario.ops[scenario.ops.length - 1].t : 0;
+  const horizon = lastOpTime + 2000;
+  for (let elapsed = 0; elapsed <= horizon; elapsed += 50) {
+    runner.tick(50);
+  }
+  runner.pause();
+
+  return lanes;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertNonDecreasing(events, method) {
+  for (let i = 1; i < events.length; i++) {
+    assert(
+      events[i].ts_ms >= events[i - 1].ts_ms,
+      `${method}: events out of order at index ${i} (${events[i - 1].ts_ms} -> ${events[i].ts_ms})`,
+    );
+  }
+}
+
+const seeds = Array.from({ length: 24 }, (_, index) => index + 11);
+const failures = [];
+
+for (const seed of seeds) {
+  try {
+    const scenario = generateScenario(seed);
+    const lanes = runScenario(scenario);
+
+    const polling = lanes.get('polling').events;
+    const trigger = lanes.get('trigger').events;
+    const log = lanes.get('log').events;
+
+    assertNonDecreasing(trigger, 'trigger');
+    assertNonDecreasing(log, 'log');
+
+    const diffPolling = diffLane('polling', scenario.ops, polling);
+    const diffTrigger = diffLane('trigger', scenario.ops, trigger);
+    const diffLog = diffLane('log', scenario.ops, log);
+
+    assert(diffPolling.totals.extra === 0, 'polling produced unexpected extra events');
+    assert(diffTrigger.totals.missing === 0 && diffTrigger.totals.extra === 0, 'trigger diverged from source ops');
+    assert(diffLog.totals.missing === 0 && diffLog.totals.extra === 0, 'log diverged from source ops');
+    assert(diffTrigger.totals.ordering === 0, 'trigger ordering drift');
+    assert(diffLog.totals.ordering === 0, 'log ordering drift');
+
+    const expectedDeletes = scenario.ops.filter(op => op.op === 'delete').length;
+    const triggerDeletes = trigger.filter(evt => evt.op === 'd').length;
+    const logDeletes = log.filter(evt => evt.op === 'd').length;
+    const pollingDeletes = polling.filter(evt => evt.op === 'd').length;
+
+    assert(triggerDeletes === expectedDeletes, `trigger delete capture mismatch (${triggerDeletes} vs ${expectedDeletes})`);
+    assert(logDeletes === expectedDeletes, `log delete capture mismatch (${logDeletes} vs ${expectedDeletes})`);
+    assert(pollingDeletes <= expectedDeletes, 'polling emitted more deletes than source ops');
+
+    assert(diffTrigger.lag.max <= 50, `trigger lag spike ${diffTrigger.lag.max}ms`);
+    assert(diffLog.lag.max <= 5, `log lag spike ${diffLog.lag.max}ms`);
+  } catch (error) {
+    failures.push({ seed, error });
+  }
+}
+
+if (failures.length) {
+  console.error(`❌ Property tests failed for ${failures.length} seed(s).`);
+  failures.forEach(failure => {
+    console.error(`  Seed ${failure.seed}: ${failure.error.message}`);
+  });
+  process.exit(1);
+}
+
+console.log(`✅ Property-based CDC invariants passed for ${seeds.length} generated scenarios.`);

--- a/web/components/LaneDiffOverlay.tsx
+++ b/web/components/LaneDiffOverlay.tsx
@@ -1,0 +1,95 @@
+import type { LaneDiffResult } from "../../sim";
+
+type LaneDiffOverlayProps = {
+  diff: LaneDiffResult | null;
+};
+
+function formatIssueLabel(issue: LaneDiffResult["issues"][number]): string {
+  const op = issue.op.toUpperCase();
+  const pk = issue.pk || "∅";
+  const expectedIndex = issue.expectedIndex != null ? `#${issue.expectedIndex}` : undefined;
+  const actualIndex = issue.actualIndex != null ? `#${issue.actualIndex}` : undefined;
+
+  if (issue.type === "missing") {
+    return `Missing ${op} for pk=${pk} (${expectedIndex ?? "expected"} @ ${issue.expectedTime ?? "?"}ms)`;
+  }
+  if (issue.type === "extra") {
+    return `Unexpected ${op} for pk=${pk} (${actualIndex ?? "emitted"} @ ${issue.actualTime ?? "?"}ms)`;
+  }
+  return `Out-of-order ${op} pk=${pk} (expected ${expectedIndex ?? "?"} before actual ${actualIndex ?? "?"})`;
+}
+
+export function LaneDiffOverlay({ diff }: LaneDiffOverlayProps) {
+  if (!diff) return null;
+
+  const { totals, issues, lag } = diff;
+  const hasIssues = totals.missing > 0 || totals.extra > 0 || totals.ordering > 0;
+  const surfaceIssues = issues.slice(0, 6);
+
+  if (!hasIssues && lag.max <= 0) {
+    return null;
+  }
+
+  return (
+    <div className="sim-shell__lane-diff" data-has-issues={hasIssues ? "true" : "false"} role="note">
+      <div className="sim-shell__lane-diff-summary">
+        {hasIssues ? (
+          <>
+            {totals.missing > 0 && (
+              <span className="sim-shell__lane-diff-chip sim-shell__lane-diff-chip--missing">
+                {totals.missing} missing
+              </span>
+            )}
+            {totals.extra > 0 && (
+              <span className="sim-shell__lane-diff-chip sim-shell__lane-diff-chip--extra">
+                {totals.extra} extra
+              </span>
+            )}
+            {totals.ordering > 0 && (
+              <span className="sim-shell__lane-diff-chip sim-shell__lane-diff-chip--ordering">
+                {totals.ordering} ordering
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="sim-shell__lane-diff-chip sim-shell__lane-diff-chip--ok">Operations aligned</span>
+        )}
+        {lag.max > 0 && (
+          <span className="sim-shell__lane-diff-chip sim-shell__lane-diff-chip--lag">
+            Max lag {Math.round(lag.max)}ms
+          </span>
+        )}
+      </div>
+
+      {(surfaceIssues.length > 0 || lag.samples.length > 0) && (
+        <details className="sim-shell__lane-diff-details">
+          <summary>Diff details</summary>
+          {surfaceIssues.length > 0 && (
+            <ul className="sim-shell__lane-diff-list">
+              {surfaceIssues.map((issue, index) => (
+                <li key={`${issue.type}-${issue.op}-${issue.pk}-${index}`}>{formatIssueLabel(issue)}</li>
+              ))}
+            </ul>
+          )}
+          {issues.length > surfaceIssues.length && (
+            <p className="sim-shell__lane-diff-more">
+              +{issues.length - surfaceIssues.length} additional difference(s)
+            </p>
+          )}
+          {lag.samples.length > 0 && (
+            <div className="sim-shell__lane-diff-lag">
+              <h4>Lag hotspots</h4>
+              <ul>
+                {lag.samples.map(sample => (
+                  <li key={`${sample.op}-${sample.pk}-${sample.actualTime}`}>
+                    {Math.round(sample.lagMs)}ms on {sample.op.toUpperCase()} pk={sample.pk}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </details>
+      )}
+    </div>
+  );
+}

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -121,6 +121,88 @@
   background: rgba(37, 99, 235, 0.2);
 }
 
+.sim-shell__lane-diff {
+  margin-top: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+  background: rgba(248, 250, 252, 0.75);
+  display: grid;
+  gap: 0.6rem;
+}
+.sim-shell__lane-diff[data-has-issues="true"] {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(254, 226, 226, 0.5);
+}
+.sim-shell__lane-diff-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+.sim-shell__lane-diff-chip {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+  font-weight: 500;
+  font-size: 0.75rem;
+}
+.sim-shell__lane-diff-chip--missing {
+  background: rgba(220, 38, 38, 0.18);
+  color: #b91c1c;
+}
+.sim-shell__lane-diff-chip--extra {
+  background: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+.sim-shell__lane-diff-chip--ordering {
+  background: rgba(14, 116, 144, 0.18);
+  color: #0e7490;
+}
+.sim-shell__lane-diff-chip--lag {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+.sim-shell__lane-diff-chip--ok {
+  background: rgba(16, 185, 129, 0.12);
+  color: #047857;
+}
+.sim-shell__lane-diff-details {
+  font-size: 0.82rem;
+  color: #1f2937;
+}
+.sim-shell__lane-diff-details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+.sim-shell__lane-diff-list {
+  margin: 0.35rem 0 0.25rem;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+.sim-shell__lane-diff-more {
+  margin: 0.1rem 0 0;
+  color: rgba(15, 23, 42, 0.7);
+}
+.sim-shell__lane-diff-lag {
+  margin-top: 0.4rem;
+}
+.sim-shell__lane-diff-lag h4 {
+  margin: 0 0 0.25rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+.sim-shell__lane-diff-lag ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
 .sim-shell__method-toggle {
   display: inline-flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Near-Term Goals

Extended comparator exports/imports to persist preferences, analytics, and lane-level diffs; share payloads now hydrate snapshots inside the legacy shell (assets/app.js:1981, assets/app.js:1211).
Added deterministic clock control API (window.cdcComparatorClock plus cdc:comparator-clock events) and lane diff overlays so tours can drive the React comparator while surfacing concrete deltas (web/App.tsx:676, web/components/LaneDiffOverlay.tsx:1, web/styles/shell.css:97).
Centralised diff analysis for reuse and exposed it via the simulator bundle (sim/analysis/diff.ts:1, sim/index.ts:1, sim/bundle.ts:1) with property-based invariants exercising all three engines (sim/tests/property-tests.mjs:1).
Froze the scenario payload contract at docs/schema/scenario-v2.json:1 and documented the completed near-term roadmap items (docs/next-steps.md:12); README now points to the new verification workflow (README.md:9).
Introduced a preflight GitHub Action mirroring npm run ci:preflight, which runs sim/web builds plus the new invariant suite (.github/workflows/preflight.yml:1, package.json:11).
Tests

npm run ci:preflight
