### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,4 +1,6 @@
 name: Preflight Checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground/security/code-scanning/1](https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground/security/code-scanning/1)

To fix the problem, you should add a `permissions` block—either at the root of the workflow file (for all jobs), or within the specific job(s)—to ensure that only the minimal required permissions are granted to the GITHUB_TOKEN. In this case, the best option is to set `permissions: contents: read` at the workflow root, which covers all jobs and steps, as no steps appear to require broader permissions.

- Add the following block after the workflow `name:` (and before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
  This change limits the permissions to read-only access on repository contents, which should be sufficient for tasks such as checking out code and running tests.

No changes to imports, methods, or variable definitions are needed; this is a YAML workflow configuration change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
