### PR TITLE
Fix default harness scenario for CI

### DIFF
--- a/scripts/run-harness-ci.mjs
+++ b/scripts/run-harness-ci.mjs
@@ -13,7 +13,7 @@ const healthUrl = "http://localhost:8089/health";
 const reportUrl = "http://localhost:8089/report";
 const connectBaseUrl = process.env.HARNESS_CONNECT_URL || "http://localhost:8083";
 const connectorsDir = path.resolve(projectRoot, "harness/connectors");
-const scenarioId = process.env.HARNESS_SCENARIO || "orders-transactions";
+const scenarioId = process.env.HARNESS_SCENARIO || "orders-items-transactions";
 
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- update the harness CI runner to use the existing `orders-items-transactions` scenario by default

## Testing
- npm run ci:preflight *(fails: Playwright browsers are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8251a610c8323829e0f8046fab438