### PR TITLE
Handle offline comparator bundle loading

### DIFF
--- a/assets/ui-shell-loader.js
+++ b/assets/ui-shell-loader.js
@@ -30,7 +30,17 @@
       }
     })();
 
-    if (assetHeaderEntries.length === 0) {
+    const shouldFetchWithHeaders = (() => {
+      if (assetHeaderEntries.length === 0) return false;
+      try {
+        const url = new URL(resolved, scriptBase);
+        return url.protocol === "http:" || url.protocol === "https:";
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!shouldFetchWithHeaders) {
       return import(/* @vite-ignore */ resolved);
     }
 


### PR DESCRIPTION
## Summary
- avoid fetching comparator bundles with custom headers when not using http(s) URLs
- allow the UI shell to load when running from local file URLs so the comparator scenarios render

## Testing
- npm run ci:preflight *(fails: Playwright could not download browsers in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f858bb38c883239cb9eca288cd4e2a