### PR TITLE
Add event mix metrics to comparator dashboards

### DIFF
--- a/src/test/unit/metricsDashboard.test.tsx
+++ b/src/test/unit/metricsDashboard.test.tsx
@@ -17,6 +17,10 @@ describe("MetricsDashboard", () => {
             lagP95: 900,
             missedDeletes: 1,
             snapshotRows: 4,
+            inserts: 4,
+            updates: 3,
+            deletes: 1,
+            schemaChanges: 1,
           },
           {
             id: "trigger",
@@ -28,6 +32,9 @@ describe("MetricsDashboard", () => {
             lagP95: 120,
             writeAmplification: 2.1,
             snapshotRows: 0,
+            inserts: 6,
+            updates: 4,
+            deletes: 2,
           },
         ]}
       />,
@@ -39,5 +46,8 @@ describe("MetricsDashboard", () => {
     expect(screen.getByText(/Missed deletes/i)).toBeInTheDocument();
     expect(screen.getByText(/Write amplification/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Snapshot rows/i)).toHaveLength(2);
+    expect(screen.getAllByText(/Change mix/i)).toHaveLength(2);
+    expect(screen.getByText(/C 4 · U 3 · D 1 · Schema 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/C 6 · U 4 · D 2/i)).toBeInTheDocument();
   });
 });

--- a/src/test/unit/metricsStrip.test.tsx
+++ b/src/test/unit/metricsStrip.test.tsx
@@ -12,6 +12,10 @@ describe("MetricsStrip", () => {
         orderingOk={false}
         consistent={true}
         writeAmplification={2.5}
+        insertCount={3}
+        updateCount={4}
+        deleteCount={5}
+        schemaChangeCount={2}
       />,
     );
 
@@ -20,6 +24,8 @@ describe("MetricsStrip", () => {
     expect(screen.getByText(/Deletes: 64%/i)).toBeInTheDocument();
     expect(screen.getByText(/Ordering: KO/i)).toBeInTheDocument();
     expect(screen.getByText(/Consistency: OK/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ops C\/U\/D: 3\/4\/5/i)).toBeInTheDocument();
+    expect(screen.getByText(/Schema: 2/i)).toBeInTheDocument();
     expect(screen.getByText(/Trigger WA: 2\.5x/i)).toBeInTheDocument();
   });
 });

--- a/src/ui/components/MetricsDashboard.tsx
+++ b/src/ui/components/MetricsDashboard.tsx
@@ -13,6 +13,10 @@ export type MetricsDashboardLane = {
   missedDeletes?: number;
   writeAmplification?: number;
   snapshotRows?: number;
+  inserts?: number;
+  updates?: number;
+  deletes?: number;
+  schemaChanges?: number;
 };
 
 export type MetricsDashboardProps = {
@@ -86,6 +90,19 @@ export const MetricsDashboard: FC<MetricsDashboardProps> = ({
                 <div>
                   <dt>Snapshot rows</dt>
                   <dd data-tooltip={TOOLTIP_COPY.snapshot}>{formatNumber(lane.snapshotRows)}</dd>
+                </div>
+              )}
+              {(typeof lane.inserts === "number" ||
+                typeof lane.updates === "number" ||
+                typeof lane.deletes === "number") && (
+                <div>
+                  <dt>Change mix</dt>
+                  <dd>
+                    C {formatNumber(lane.inserts ?? 0)} · U {formatNumber(lane.updates ?? 0)} · D {formatNumber(lane.deletes ?? 0)}
+                    {typeof lane.schemaChanges === "number" && lane.schemaChanges > 0
+                      ? ` · Schema ${formatNumber(lane.schemaChanges)}`
+                      : ""}
+                  </dd>
                 </div>
               )}
               {typeof lane.missedDeletes === "number" && (

--- a/src/ui/components/MetricsStrip.tsx
+++ b/src/ui/components/MetricsStrip.tsx
@@ -7,6 +7,10 @@ export type MetricsStripProps = {
   orderingOk: boolean;
   consistent: boolean;
   writeAmplification?: number;
+  insertCount: number;
+  updateCount: number;
+  deleteCount: number;
+  schemaChangeCount: number;
 };
 
 export const MetricsStrip: FC<MetricsStripProps> = ({
@@ -16,6 +20,10 @@ export const MetricsStrip: FC<MetricsStripProps> = ({
   orderingOk,
   consistent,
   writeAmplification,
+  insertCount,
+  updateCount,
+  deleteCount,
+  schemaChangeCount,
 }) => {
   return (
     <div role="status" aria-live="polite">
@@ -23,6 +31,14 @@ export const MetricsStrip: FC<MetricsStripProps> = ({
       <span>Deletes: {Math.round(deletesPct)}%</span> ·
       <span>Ordering: {orderingOk ? "OK" : "KO"}</span> ·
       <span>Consistency: {consistent ? "OK" : "Drift"}</span>
+      {" "}·<span>
+        Ops C/U/D: {insertCount}/{updateCount}/{deleteCount}
+      </span>
+      {schemaChangeCount > 0 && (
+        <>
+          {" "}·<span>Schema: {schemaChangeCount}</span>
+        </>
+      )}
       {typeof writeAmplification === "number" && (
         <>
           {" "}·<span>Trigger WA: {writeAmplification.toFixed(1)}x</span>

--- a/web/stories/MetricsDashboard.stories.tsx
+++ b/web/stories/MetricsDashboard.stories.tsx
@@ -12,6 +12,10 @@ const lanes = [
     lagP95: 980,
     missedDeletes: 3,
     snapshotRows: 120,
+    inserts: 18,
+    updates: 20,
+    deletes: 10,
+    schemaChanges: 2,
   },
   {
     id: "trigger",
@@ -23,6 +27,10 @@ const lanes = [
     lagP95: 140,
     writeAmplification: 2.4,
     snapshotRows: 48,
+    inserts: 16,
+    updates: 22,
+    deletes: 10,
+    schemaChanges: 1,
   },
   {
     id: "log",
@@ -33,6 +41,9 @@ const lanes = [
     lagP50: 35,
     lagP95: 60,
     snapshotRows: 120,
+    inserts: 18,
+    updates: 24,
+    deletes: 6,
   },
 ];
 

--- a/web/stories/MetricsStrip.stories.tsx
+++ b/web/stories/MetricsStrip.stories.tsx
@@ -8,6 +8,10 @@ const base = {
   orderingOk: true,
   consistent: true,
   writeAmplification: 1.4,
+  insertCount: 12,
+  updateCount: 18,
+  deleteCount: 4,
+  schemaChangeCount: 1,
 };
 
 export const Balanced = () => <MetricsStrip {...base} />;
@@ -19,6 +23,10 @@ export const DeleteGap = () => (
     orderingOk={false}
     consistent={false}
     writeAmplification={2.6}
+    insertCount={20}
+    updateCount={24}
+    deleteCount={3}
+    schemaChangeCount={0}
   />
 );
 


### PR DESCRIPTION
## Summary
- surface insert, update, delete, and schema-change counts in the metrics strip and dashboard lanes
- update comparator analytics map, stories, and tests to cover the new event mix metrics

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f8581086908323a0929e3babfbde20