### PR TITLE
Surface snapshot rows in event log summary

### DIFF
--- a/src/test/unit/eventLog.test.tsx
+++ b/src/test/unit/eventLog.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EventLog } from "../../ui/components/EventLog";
+
+const sampleEvent = {
+  id: "evt-1",
+  op: "c",
+};
+
+describe("EventLog", () => {
+  it("renders snapshot row stats when provided", () => {
+    render(
+      <EventLog
+        events={[sampleEvent]}
+        stats={{ produced: 1, consumed: 1, backlog: 0, snapshotRows: 5 }}
+      />,
+    );
+
+    expect(screen.getByText(/Produced 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Consumed 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Backlog 0/)).toBeInTheDocument();
+    expect(screen.getByText(/Snapshot rows 5/)).toBeInTheDocument();
+  });
+
+  it("omits snapshot rows when not provided", () => {
+    render(<EventLog events={[sampleEvent]} stats={{ produced: 2, consumed: 2, backlog: 1 }} />);
+
+    expect(screen.queryByText(/Snapshot rows/)).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/components/EventLog.tsx
+++ b/src/ui/components/EventLog.tsx
@@ -20,6 +20,7 @@ export type EventLogStats = {
   produced: number;
   consumed: number;
   backlog: number;
+  snapshotRows?: number;
 };
 
 export type EventLogFilters = {
@@ -163,7 +164,17 @@ export const EventLog: FC<EventLogProps> = ({
           <h3>Event Log</h3>
           {stats && (
             <p className="cdc-event-log__stats">
-              Produced {stats.produced} &middot; Consumed {stats.consumed} &middot; Backlog {stats.backlog}
+              <span>Produced {stats.produced}</span>
+              {" · "}
+              <span>Consumed {stats.consumed}</span>
+              {" · "}
+              <span>Backlog {stats.backlog}</span>
+              {typeof stats.snapshotRows === "number" && (
+                <>
+                  {" · "}
+                  <span>Snapshot rows {stats.snapshotRows}</span>
+                </>
+              )}
             </p>
           )}
         </div>

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1746,7 +1746,7 @@ export function App() {
   const aggregateEventBusTotals = useMemo(
     () => {
       if (!eventBusEnabled) {
-        return { produced: 0, consumed: 0, backlog: 0 };
+        return { produced: 0, consumed: 0, backlog: 0, snapshotRows: 0 };
       }
       return activeMethods.reduce(
         (acc, method) => {
@@ -1755,9 +1755,10 @@ export function App() {
           acc.produced += summary.produced;
           acc.consumed += summary.consumed;
           acc.backlog += summary.backlog;
+          acc.snapshotRows += summary.snapshotRows;
           return acc;
         },
-        { produced: 0, consumed: 0, backlog: 0 },
+        { produced: 0, consumed: 0, backlog: 0, snapshotRows: 0 },
       );
     },
     [activeMethods, laneRuntimeSummaries, eventBusEnabled],

--- a/web/stories/EventLog.stories.tsx
+++ b/web/stories/EventLog.stories.tsx
@@ -60,7 +60,7 @@ const sampleEvents: EventLogRow[] = [
 const baseProps = {
   className: "cdc-event-log",
   events: sampleEvents,
-  stats: { produced: 3, consumed: 3, backlog: 0 },
+  stats: { produced: 3, consumed: 3, backlog: 0, snapshotRows: 6 },
   totalCount: sampleEvents.length,
   filters: {},
   filterOptions: {
@@ -84,7 +84,7 @@ export const Empty = () => (
   <EventLog
     {...baseProps}
     events={[]}
-    stats={{ produced: 0, consumed: 0, backlog: 0 }}
+    stats={{ produced: 0, consumed: 0, backlog: 0, snapshotRows: 0 }}
     totalCount={0}
   />
 );


### PR DESCRIPTION
## Summary
- extend event log stats to optionally include snapshot row counts and display them in the header
- aggregate snapshot row totals across lanes so the comparator passes the data to the event log
- document the new stats in the Storybook story and add unit coverage for the component behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f85ca87d7c832387d6f890f07a88ff