### PR TITLE
Docs: map event bus architecture for onboarding

### DIFF
--- a/docs/dev-onboarding.md
+++ b/docs/dev-onboarding.md
@@ -5,14 +5,36 @@
 npm install
 ```
 
+## Architecture crash course
+
+The project uses a shared `src/` workspace that is consumed by both the simulator (data generation + adapters) and the comparator web shell. The top-level layout mirrors the implementation plan in `docs/IMPLEMENTATION_PLAN.md`:
+
+```
+src/
+  domain/        # shared record + schema types
+  engine/        # event bus, scheduler, metrics, CDC controller
+  modes/         # log-, query-, and trigger-based adapters
+  features/      # presets, scripted scenarios, normalisers
+  ui/            # reusable UI primitives (event log, metrics widgets, walkthrough)
+  test/          # vitest suites covering adapters + UI
+```
+
+All CDC modes publish into a shared `EventBus` (`src/engine/eventBus.ts`). The bus assigns offsets per topic and feeds the metrics store so UI components (event log, metrics strip, lane diff overlay) can render consistent backlog/lag views. When wiring new behaviour make sure:
+
+1. The adapter invokes the provided `emit` callback from `CDCController` instead of publishing directly.
+2. Metrics updates (`onProduced`, `onConsumed`, `recordMissedDelete`, `recordWriteAmplification`) stay in sync with adapter semantics.
+3. UI consumers derive read models from the bus rather than bespoke stores—see `web/App.tsx` for integration examples.
+
 ## Common workflows
 - Review the day-to-day checklist in `../development.md` for the branching + PR process.
 - Run the React comparator + simulator side-by-side: `npm run dev:all` (spawns `npm run dev:sim` and `npm run dev:web` in parallel).
 - Focus on the comparator shell only: `npm run dev:web` (ensure you have a fresh `npm run build:sim` first).
+- Generate fresh sim bundles before booting the comparator: `npm run build:sim`.
 - Property-test the engines: `npm run test:sim`.
 - Type-check and unit test the shared engine/ui packages: `npx tsc --noEmit` and `npm run test:unit` (see `/src/test`).
 - Smoke the Playwright flows, including the apply-on-commit transaction scenario: `npm run test:e2e`.
 - Build artefacts for the playground: `npm run build`.
+- Refresh the nightly harness summary (requires a GitHub token with workflow scope): `GITHUB_TOKEN=... npm run harness:history`.
 
 ## Component stories
 We use [Ladle](https://ladle.dev/) to iterate on UI primitives:

--- a/docs/harness-guide.md
+++ b/docs/harness-guide.md
@@ -1,6 +1,6 @@
 # Harness Guide
 
-This harness spins up Postgres + Debezium Kafka Connect, replays a shared scenario against the database, and verifies emitted change events.
+This harness spins up Postgres + Debezium Kafka Connect, replays a shared scenario against the database, and verifies emitted change events. It mirrors the in-browser simulator: the generator writes source mutations, the change-capture connector appends to Kafka topics, and the verifier consumes offsets in order—exactly how the in-memory `EventBus` behaves in `src/engine/eventBus.ts`.
 
 ## Prerequisites
 - Docker Desktop (or `docker compose` CLI)
@@ -24,6 +24,12 @@ make status    # JSON report on http://localhost:8089/report
 open http://localhost:8089   # HTML summary
 ```
 
+### How the harness maps to the playground
+
+- **Producer parity** – the generator mirrors `src/modes/*` adapters. Watching harness logs while the web comparator runs helps trace how inserts/updates/deletes should schedule commits and offsets.
+- **Transport parity** – Kafka topics expose offsets and partitions that line up with the simulator `EventBus`. When debugging ordering or backlog mismatches, compare the harness report offsets to the in-app Event Log.
+- **Consumer parity** – the verifier respects pause/resume semantics just like the comparator’s downstream consumer. Use it to validate backlog and lag calculations when tweaking `MetricsStore` logic.
+
 ## Iterating
 - `make replay` triggers the generator again without resetting Kafka topics.
 - `make snapshots` refreshes fixtures in `harness/fixtures/` from the canonical shared scenarios.
@@ -34,7 +40,7 @@ When running `orders-transactions`, open the comparator with `Apply-on-commit` t
 Health checks gate the generator/verifier so they don’t run until Postgres, Kafka, and Connect are ready. Generator retries its connection loop, so you get deterministic start-up even on cold hosts.
 
 ## Reports
-The verifier exposes JSON (`/report`) and HTML (`/`) views on port 8089. Both use the shared diff engine to flag missing/extra/out-of-order events and max lag so you can reason about CDC parity at a glance.
+The verifier exposes JSON (`/report`) and HTML (`/`) views on port 8089. Both use the shared diff engine to flag missing/extra/out-of-order events and max lag so you can reason about CDC parity at a glance. The same diff heuristics feed the lane diff overlay in `src/ui/components/LaneDiffOverlay.tsx`, so discrepancies surfaced in the harness translate directly to UI badges.
 
 Nightly automation runs `npm run ci:harness` against the Orders + Items Transactions scenario and uploads both `harness-report.json` and `harness-report.html` under the **Harness Nightly** workflow in GitHub Actions. Download the latest run to inspect table-level summaries and field-level mismatches without bringing the stack up locally.
 Configure the `SLACK_WEBHOOK_URL` repository secret to receive PASS/FAIL notifications from the nightly job in Slack.


### PR DESCRIPTION
## Summary
- expand the onboarding guide with a crash course on the shared src/ architecture and event bus usage
- connect the harness guide to the simulator event bus and lane diff overlay so parity checks map back to the UI

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f85f7724348323855933deeb2f7b3f