### PR TITLE
Serve scenario definitions through Eleventy passthrough

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,0 +1,5 @@
+export default function(eleventyConfig) {
+  eleventyConfig.addPassthroughCopy({
+    "src/data/scenarios.json": "data/scenarios.json",
+  });
+}

--- a/scripts/lint-scenarios.mjs
+++ b/scripts/lint-scenarios.mjs
@@ -11,6 +11,7 @@ const ALLOWED_PREFIXES = [
   "harness/verifier/",
   "harness/generator/",
   "docs/schema/",
+  "src/data/",
   "sim/tests/"
 ];
 const ALLOWED_FILES = new Set([

--- a/src/data/scenarios.json
+++ b/src/data/scenarios.json
@@ -1,0 +1,752 @@
+[
+  {
+    "id": "crud-basic",
+    "name": "CRUD Basic",
+    "label": "CRUD Basic",
+    "description": "Teaching delete visibility basics.",
+    "highlight": "Minimal ops for first-time comparator demos.",
+    "tags": [
+      "crud",
+      "basics"
+    ],
+    "seed": 42,
+    "table": "customers",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "1",
+        "name": "Alice",
+        "email": "alice@contoso.io"
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 100,
+        "op": "insert",
+        "table": "customers",
+        "pk": {
+          "id": "1"
+        },
+        "after": {
+          "name": "Alice",
+          "email": "alice@example.com"
+        }
+      },
+      {
+        "t": 350,
+        "op": "update",
+        "table": "customers",
+        "pk": {
+          "id": "1"
+        },
+        "after": {
+          "email": "alice@contoso.io"
+        }
+      },
+      {
+        "t": 700,
+        "op": "delete",
+        "table": "customers",
+        "pk": {
+          "id": "1"
+        }
+      }
+    ]
+  },
+  {
+    "id": "omnichannel-orders",
+    "name": "Omnichannel Orders",
+    "label": "Omnichannel Orders",
+    "description": "Walking through status transitions and fulfilment edge cases.",
+    "highlight": "Mix of inserts/updates with delete coverage; great for lag comparisons.",
+    "tags": [
+      "orders",
+      "lag",
+      "fulfilment"
+    ],
+    "seed": 21,
+    "table": "orders",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "customer_id",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "channel",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "total",
+        "type": "number",
+        "pk": false
+      },
+      {
+        "name": "pickup_ts",
+        "type": "number",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "ORD-501",
+        "customer_id": "C-19",
+        "status": "collected",
+        "channel": "store-108",
+        "total": 189.5,
+        "pickup_ts": 420
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 120,
+        "op": "insert",
+        "table": "orders",
+        "pk": {
+          "id": "ORD-501"
+        },
+        "after": {
+          "customer_id": "C-19",
+          "status": "pending",
+          "channel": "web",
+          "total": 189.5
+        }
+      },
+      {
+        "t": 240,
+        "op": "update",
+        "table": "orders",
+        "pk": {
+          "id": "ORD-501"
+        },
+        "after": {
+          "status": "ready_for_pickup",
+          "channel": "store-108"
+        }
+      },
+      {
+        "t": 260,
+        "op": "insert",
+        "table": "fulfilment_events",
+        "pk": {
+          "id": "FUL-501-1"
+        },
+        "after": {
+          "order_id": "ORD-501",
+          "type": "picking",
+          "associate": "EMP-88"
+        }
+      },
+      {
+        "t": 420,
+        "op": "update",
+        "table": "orders",
+        "pk": {
+          "id": "ORD-501"
+        },
+        "after": {
+          "status": "collected",
+          "pickup_ts": 420
+        }
+      },
+      {
+        "t": 600,
+        "op": "delete",
+        "table": "fulfilment_events",
+        "pk": {
+          "id": "FUL-501-1"
+        }
+      }
+    ]
+  },
+  {
+    "id": "real-time-payments",
+    "name": "Real-time Payments",
+    "label": "Real-time Payments",
+    "description": "Demonstrating idempotent updates or risk review flows.",
+    "highlight": "Trigger overhead tuning + delete capture expectations.",
+    "tags": [
+      "payments",
+      "risk",
+      "latency"
+    ],
+    "seed": 73,
+    "table": "payments",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "account_id",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "amount",
+        "type": "number",
+        "pk": false
+      },
+      {
+        "name": "currency",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "released_by",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "settled_ts",
+        "type": "number",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "PAY-009",
+        "account_id": "AC-77",
+        "amount": 985.4,
+        "currency": "USD",
+        "status": "settled",
+        "settled_ts": 280
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 50,
+        "op": "insert",
+        "table": "payments",
+        "pk": {
+          "id": "PAY-009"
+        },
+        "after": {
+          "account_id": "AC-77",
+          "amount": 985.4,
+          "currency": "USD",
+          "status": "authorised"
+        }
+      },
+      {
+        "t": 95,
+        "op": "insert",
+        "table": "risk_reviews",
+        "pk": {
+          "id": "RR-009"
+        },
+        "after": {
+          "payment_id": "PAY-009",
+          "score": 412,
+          "disposition": "manual"
+        }
+      },
+      {
+        "t": 140,
+        "op": "update",
+        "table": "risk_reviews",
+        "pk": {
+          "id": "RR-009"
+        },
+        "after": {
+          "disposition": "approved"
+        }
+      },
+      {
+        "t": 180,
+        "op": "update",
+        "table": "payments",
+        "pk": {
+          "id": "PAY-009"
+        },
+        "after": {
+          "status": "released",
+          "released_by": "agent-5"
+        }
+      },
+      {
+        "t": 220,
+        "op": "delete",
+        "table": "risk_reviews",
+        "pk": {
+          "id": "RR-009"
+        }
+      },
+      {
+        "t": 280,
+        "op": "update",
+        "table": "payments",
+        "pk": {
+          "id": "PAY-009"
+        },
+        "after": {
+          "status": "settled",
+          "settled_ts": 280
+        }
+      }
+    ]
+  },
+  {
+    "id": "iot-telemetry",
+    "name": "IoT Telemetry",
+    "label": "IoT Telemetry",
+    "description": "Showing rolling measurements with anomaly flags.",
+    "highlight": "Highlights soft-delete vs. log consistency and clock controls.",
+    "tags": [
+      "iot",
+      "telemetry",
+      "anomaly"
+    ],
+    "seed": 88,
+    "table": "device_readings",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "device_id",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "temp_c",
+        "type": "number",
+        "pk": false
+      },
+      {
+        "name": "humidity",
+        "type": "number",
+        "pk": false
+      },
+      {
+        "name": "anomaly",
+        "type": "bool",
+        "pk": false
+      },
+      {
+        "name": "anomaly_reason",
+        "type": "string",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "DEV-5@130",
+        "device_id": "DEV-5",
+        "temp_c": 19.2,
+        "humidity": 0.39,
+        "anomaly": false
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 10,
+        "op": "insert",
+        "table": "device_readings",
+        "pk": {
+          "id": "DEV-5@10"
+        },
+        "after": {
+          "device_id": "DEV-5",
+          "temp_c": 18.4,
+          "humidity": 0.41,
+          "anomaly": false
+        }
+      },
+      {
+        "t": 55,
+        "op": "update",
+        "table": "device_readings",
+        "pk": {
+          "id": "DEV-5@10"
+        },
+        "after": {
+          "temp_c": 28.9,
+          "anomaly": true,
+          "anomaly_reason": "spike"
+        }
+      },
+      {
+        "t": 130,
+        "op": "insert",
+        "table": "device_readings",
+        "pk": {
+          "id": "DEV-5@130"
+        },
+        "after": {
+          "device_id": "DEV-5",
+          "temp_c": 19.2,
+          "humidity": 0.39,
+          "anomaly": false
+        }
+      },
+      {
+        "t": 200,
+        "op": "delete",
+        "table": "device_readings",
+        "pk": {
+          "id": "DEV-5@10"
+        }
+      }
+    ]
+  },
+  {
+    "id": "schema-evolution",
+    "name": "Schema Evolution",
+    "label": "Schema Evolution",
+    "description": "Demonstrating column additions while capturing changes.",
+    "highlight": "Compare immediate log/trigger propagation with polling lag.",
+    "tags": [
+      "schema",
+      "backfill"
+    ],
+    "seed": 64,
+    "table": "customers",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "email",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "loyalty_tier",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "preferences",
+        "type": "json",
+        "pk": false
+      }
+    ],
+    "schemaVersion": 2,
+    "rows": [
+      {
+        "id": "C-881",
+        "name": "Ishaan",
+        "email": "ishaan@example.net",
+        "loyalty_tier": "bronze",
+        "preferences": {
+          "marketing_opt_in": false,
+          "locale": "en-GB"
+        }
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 75,
+        "op": "insert",
+        "table": "customers",
+        "pk": {
+          "id": "C-880"
+        },
+        "after": {
+          "name": "Mira",
+          "email": "mira@example.net",
+          "loyalty_tier": "silver"
+        }
+      },
+      {
+        "t": 140,
+        "op": "update",
+        "table": "customers",
+        "pk": {
+          "id": "C-880"
+        },
+        "after": {
+          "loyalty_tier": "gold",
+          "preferences": {
+            "marketing_opt_in": true
+          }
+        }
+      },
+      {
+        "t": 210,
+        "op": "insert",
+        "table": "customers",
+        "pk": {
+          "id": "C-881"
+        },
+        "after": {
+          "name": "Ishaan",
+          "email": "ishaan@example.net",
+          "loyalty_tier": "bronze"
+        }
+      },
+      {
+        "t": 360,
+        "op": "update",
+        "table": "customers",
+        "pk": {
+          "id": "C-881"
+        },
+        "after": {
+          "preferences": {
+            "marketing_opt_in": false,
+            "locale": "en-GB"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "orders-items-transactions",
+    "name": "Orders + Items Transactions",
+    "label": "Orders + Items Transactions",
+    "description": "Teaching multi-table commit semantics.",
+    "highlight": "Toggle apply-on-commit to keep orders/items destinations consistent.",
+    "tags": [
+      "transactions",
+      "orders"
+    ],
+    "seed": 58,
+    "table": "orders",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "customer_id",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "pk": false
+      },
+      {
+        "name": "subtotal",
+        "type": "number",
+        "pk": false
+      },
+      {
+        "name": "shipped_ts",
+        "type": "number",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "ORD-720",
+        "customer_id": "C-32",
+        "status": "shipped",
+        "subtotal": 412.5,
+        "shipped_ts": 520
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 300,
+        "op": "insert",
+        "table": "orders",
+        "pk": {
+          "id": "ORD-720"
+        },
+        "after": {
+          "customer_id": "C-32",
+          "status": "pending",
+          "subtotal": 412.5
+        },
+        "txn": {
+          "id": "TX-720",
+          "index": 0,
+          "total": 3
+        }
+      },
+      {
+        "t": 300,
+        "op": "insert",
+        "table": "order_items",
+        "pk": {
+          "id": "ORD-720-1"
+        },
+        "after": {
+          "order_id": "ORD-720",
+          "sku": "SKU-9",
+          "qty": 2,
+          "price": 99.5
+        },
+        "txn": {
+          "id": "TX-720",
+          "index": 1,
+          "total": 3
+        }
+      },
+      {
+        "t": 300,
+        "op": "insert",
+        "table": "order_items",
+        "pk": {
+          "id": "ORD-720-2"
+        },
+        "after": {
+          "order_id": "ORD-720",
+          "sku": "SKU-44",
+          "qty": 1,
+          "price": 213.5
+        },
+        "txn": {
+          "id": "TX-720",
+          "index": 2,
+          "total": 3,
+          "last": true
+        }
+      },
+      {
+        "t": 520,
+        "op": "update",
+        "table": "orders",
+        "pk": {
+          "id": "ORD-720"
+        },
+        "after": {
+          "status": "shipped",
+          "shipped_ts": 520
+        }
+      }
+    ]
+  },
+  {
+    "id": "burst-updates",
+    "name": "Burst Updates",
+    "label": "Burst Updates",
+    "description": "Stressing lag/ordering behaviour under rapid updates.",
+    "highlight": "Highlights polling gaps and diff overlays.",
+    "tags": [
+      "lag",
+      "polling"
+    ],
+    "seed": 7,
+    "table": "widgets",
+    "schema": [
+      {
+        "name": "id",
+        "type": "string",
+        "pk": true
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "pk": false
+      }
+    ],
+    "rows": [
+      {
+        "id": "W-1",
+        "status": "ready"
+      }
+    ],
+    "events": [],
+    "ops": [
+      {
+        "t": 100,
+        "op": "insert",
+        "table": "widgets",
+        "pk": {
+          "id": "W-1"
+        },
+        "after": {
+          "status": "new"
+        }
+      },
+      {
+        "t": 150,
+        "op": "update",
+        "table": "widgets",
+        "pk": {
+          "id": "W-1"
+        },
+        "after": {
+          "status": "processing"
+        }
+      },
+      {
+        "t": 200,
+        "op": "update",
+        "table": "widgets",
+        "pk": {
+          "id": "W-1"
+        },
+        "after": {
+          "status": "picking"
+        }
+      },
+      {
+        "t": 260,
+        "op": "update",
+        "table": "widgets",
+        "pk": {
+          "id": "W-1"
+        },
+        "after": {
+          "status": "packing"
+        }
+      },
+      {
+        "t": 320,
+        "op": "update",
+        "table": "widgets",
+        "pk": {
+          "id": "W-1"
+        },
+        "after": {
+          "status": "ready"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add an Eleventy passthrough so scenarios.json is published under /data
- check in src/data/scenarios.json so the static site can serve the shared scenarios
- permit the lint-scenarios script to allow JSON stored under src/data

## Testing
- npm run lint:scenarios

------
https://chatgpt.com/codex/tasks/task_e_68f8671835dc8323961eb61ff5603911