### PR TITLE
feat: add consumer apply throttle control

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -151,9 +151,10 @@ export type Metrics = {
     - Acceptance: tooltips can be toggled off; stored in localStorage.
 
 12. **High-volume generator + replay (optional P2)**
-    - Generator: N changes/sec, burst mode. Consumer throttle knob: max events/second.
-    - Replay: reset destination, replay last captured trace.
-    - Acceptance: users can create artificial lag and watch recovery.
+   - Generator: N changes/sec, burst mode. Consumer throttle knob: max events/second.
+   - Replay: reset destination, replay last captured trace.
+   - Acceptance: users can create artificial lag and watch recovery.
+   - 🔄 Consumer throttle control shipped in comparator shell; generator + replay still pending.
 
 ## UI Changes (surgical)
 - New top bar: Mode | Preset | Start/Stop | Pause/Resume Apply | Polling (QUERY).

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -68,6 +68,40 @@
   height: 1rem;
 }
 
+.sim-shell__consumer-rate {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.sim-shell__consumer-rate label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #1f2937;
+}
+
+.sim-shell__consumer-rate label span {
+  font-weight: 500;
+}
+
+.sim-shell__consumer-rate input[type="range"] {
+  width: 140px;
+}
+
+.sim-shell__consumer-rate[data-enabled="false"] {
+  opacity: 0.75;
+}
+
+.sim-shell__consumer-rate button {
+  white-space: nowrap;
+}
+
 .sim-shell__actions button,
 .sim-shell__actions select {
   padding: 0.55rem 0.85rem;


### PR DESCRIPTION
## Summary
- add a throttleable apply rate control to the comparator shell, including persisted preferences and telemetry hooks
- enforce consumer rate limits when draining the event bus so throttling builds backlog predictably
- note the shipped throttle knob in the implementation plan

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f868be0e848323beaef17c96ba735b