### PR TITLE
Clarify v1 release scope summary

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,6 +2,19 @@
 
 Status: v1
 
+## Version History
+| Release | Highlights | Notes |
+| --- | --- | --- |
+| **v1.0.0** (current) | `comparator_v2` GA with the React comparator shell, multi-mode CDC engines, lane diff overlays, and the transactional “Orders + Items” scenario. | See [`docs/enablement/release-notes.md`](./enablement/release-notes.md) for the full narrative; statuses mirror [`docs/next-steps.md`](./next-steps.md).
+
+### Current Release Scope (v1.0.0)
+_Status icons align with the sprint tracker so both documents stay in sync._
+- ✅ **Comparator architecture** – The React comparator shell streams polling, trigger, and log adapters through the shared EventBus, scheduler, metrics store, and CDC state machine under `src/engine`/`src/modes`.
+- ✅ **Event visibility & insights** – Event Log filters/export, lane diff overlays, metrics strip + dashboard, backlog/lag instrumentation, and local telemetry buffer surface CDC parity gaps.
+- ✅ **Guided demos & presets** – Scenario gallery, vendor presets, guided walkthrough copy, and the apply-on-commit toggle cover multi-table, schema, and burst-update stories out of the box.
+- ✅ **Reliability controls** – Controlled CRUD flows, pause/resume apply, consumer throughput throttling, query-mode polling cadence + delete messaging, and feature flag governance keep demonstrations stable.
+- ✅ **Quality gates & ops tooling** – Property-based simulator tests, unit + Playwright suites, harness verifier, launch readiness plan, and enablement collateral ship alongside the experience.
+
 ## Goals (blunt + prioritized)
 - **P0**: Fix CRUD reliability, add **Event Log**, add **Pause/Resume**, add **Polling Interval** control, and **make Query-based limitations explicit**.
 - **P0**: Introduce **Event Bus** abstraction (to model Kafka/topic + offsets).

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,5 +1,7 @@
 # Implementation Next Steps
 
+> ℹ️ **Release sync:** The shipped scope for v1 is tracked in [`docs/IMPLEMENTATION_PLAN.md`](./IMPLEMENTATION_PLAN.md#current-release-scope-v1-0-0). Update both documents together when statuses change.
+
 ## Sprint Kickoff Focus (P0)
 - Stand up the new `/src` module layout (engine, modes, domain, ui, features, test) and add minimal scaffolding exports. ✅
 - Implement the core `EventBus`, `CDCController` state machine skeleton, and shared `MetricsStore` interfaces. ✅


### PR DESCRIPTION
## Summary
- capture v1.0.0 in a version history table that links to the release notes and notes alignment with the sprint tracker
- rewrite the current release scope bullets to reflect the shipped comparator architecture, insights, demos, reliability, and ops tooling
- update the next steps doc to point at the new anchor so the sync callout still works

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f86dc7e2548323a1aae6606324833a