### PR TITLE
Add feature flag matrix documentation

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -205,6 +205,7 @@ export type Metrics = {
 ## Rollout Plan
 - Feature flags: `ff_event_bus`, `ff_pause_resume`, `ff_query_slider`, `ff_trigger_mode`, `ff_schema_demo`, `ff_multitable`, `ff_metrics`, `ff_walkthrough`.
 - Release order: P0 bundle (event bus, pause/resume, query slider, CRUD fix, EventLog) -> P1 (trigger mode, schema demo, multitable, metrics, walkthrough, presets) -> P2 (generator, replay, second consumer).
+- Track owners, default states, and activation sequencing in [`docs/feature-flags.md`](./feature-flags.md).
 - Add `CHANGELOG.md`.
 
 ## Acceptance Criteria (summarized)

--- a/docs/dev-onboarding.md
+++ b/docs/dev-onboarding.md
@@ -39,6 +39,8 @@ Source ops ─▶ Mode adapter (log/query/trigger)
 4. **MetricsStore** exposes produced/consumed counts, lag percentiles, missed delete counters, and snapshot row tallies that power UI components.
 5. **Feature hooks** (schema walkthrough, apply-on-commit, presets) hang off the controller/runtime layer so both the simulator and harness stay in sync.
 
+Refer to [`docs/feature-flags.md`](./feature-flags.md) for the current owner + rollout matrix when you need to toggle experiences locally or for demos.
+
 All CDC modes publish into a shared `EventBus` (`src/engine/eventBus.ts`). The bus assigns offsets per topic and feeds the metrics store so UI components (event log, metrics strip, lane diff overlay) can render consistent backlog/lag views. When wiring new behaviour make sure:
 
 1. The adapter invokes the provided `emit` callback from `CDCController` instead of publishing directly.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,18 @@
+# Feature Flag Matrix
+
+This matrix tracks the major feature flags used in the CDC playground, summarising ownership, intent, defaults, and rollout sequencing so teams can coordinate launches and support.
+
+| Flag | Owner | Purpose | Default State | Rollout Plan |
+| --- | --- | --- | --- | --- |
+| `comparator_v2` | Eng Enablement | Controls release of the refreshed comparator UI with diff overlays and guided experiences. | Cohort-based: enabled for internal accounts first, then beta allowlist, before becoming default-on at GA. | Four-week rollout covering internal dogfood, design partner beta, GA enablement, and post-launch review checkpoints. |
+| `ff_crud_fix` | Comparator Engineering | Hardens CRUD flows with controlled inputs, single-write semantics, and surfaced error toasts. | Enabled by default via the Appwrite seed list. | Ships as part of the P0 feature bundle alongside Event Log, Event Bus, Pause/Resume, and Query slider workstreams. |
+| `ff_event_log` | Comparator Engineering | Unlocks the Event Log panel with filters, actions, and produced/consumed counters. | Enabled by default via the Appwrite seed list. | Ships in the P0 bundle; remains on once the Event Log meets acceptance criteria. |
+| `ff_event_bus` | Comparator Engineering | Shows the Event Bus column with backlog and lag metrics sourced from the shared EventBus. | Enabled by default via the Appwrite seed list. | Ships in the P0 bundle to support pause/resume and backlog instrumentation. |
+| `ff_pause_resume` | Comparator Engineering | Enables pause/resume controls so users can observe backlog growth and draining behaviour. | Enabled by default via the Appwrite seed list. | Ships in the P0 bundle together with Event Bus visibility. |
+| `ff_query_slider` | Comparator Engineering | Provides the polling interval slider and query-mode lossiness messaging. | Enabled by default via the Appwrite seed list. | Ships in the P0 bundle to highlight query-mode trade-offs. |
+| `ff_trigger_mode` | Comparator Engineering | Adds the trigger-based CDC adapter with write-amplification modelling. | Disabled by default until the P1 rollout window. | Activates in the P1 wave after the P0 bundle proves stable. |
+| `ff_schema_demo` | Comparator Engineering | Drives the schema change demo with add/drop column flows and schema version badges. | Disabled by default until the P1 rollout window. | Activates in the P1 wave alongside trigger mode and walkthrough enhancements. |
+| `ff_multitable` | Comparator Engineering | Exposes multi-table + transactional scenarios with apply-on-commit coordination. | Disabled by default until the P1 rollout window. | Activates in the P1 wave once multi-table flows clear verification. |
+| `ff_metrics` | Comparator Engineering | Surfaces the metrics dashboard with backlog, lag percentiles, and lane checks telemetry. | Disabled by default until the P1 rollout window. | Activates in the P1 wave after telemetry validation. |
+| `ff_walkthrough` | Comparator Engineering | Enables the guided tooltips and glossary walkthrough experience. | Disabled by default until the P1 rollout window. | Activates in the P1 wave together with schema demo improvements. |
+


### PR DESCRIPTION
## Summary
- document the feature flag matrix with owners, defaults, and rollout sequencing
- link the implementation plan and developer onboarding guide to the shared matrix for visibility

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f86dca6a2c8323b87f104f6f60f88d