### PR TITLE
Document deferred storage integration

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -42,6 +42,14 @@ Status: v1
 pgsql
 ```
 
+### Storage integration (Deferred)
+- **Status**: Deferred until external dependencies are ready.
+- **Remaining work**: implement the domain `storage.ts` helper to persist source/destination tables between refreshes and add the optional Appwrite-backed persistence layer/configuration hooks.
+- **Prerequisites/blockers**:
+  - Confirm the data model and interface for the storage helper so it matches upcoming engine/state machine expectations.
+  - Provision an Appwrite project (API keys, self-hosted endpoint) and decide on authentication + data retention policies for demo data.
+  - Document environment configuration (env vars, SDK initialization) so the integration can be toggled without breaking the pure in-memory demo mode.
+
 ### Core data types (TypeScript)
 ```ts
 // /src/domain/types.ts


### PR DESCRIPTION
## Summary
- mark the storage integration plan as deferred within the implementation plan
- list the remaining storage work and the prerequisites blocking it

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f86dcb65e48323a3c9d46e8b54d974