### PR TITLE
Update onboarding guide with planning and status references

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -300,3 +300,6 @@ export const PRESETS = {
 - Query mode demonstrably lossy with scenarios.
 - Basic glossary + tooltips shipped.
 - Tests green; CI runs unit + e2e headless.
+
+## Changelog
+- **v1 (current)** – Establishes the unified `/src` workspace layout, core EventBus + CDCController scaffolding, pause/resume, query polling controls, and the launch-ready Event Log.

--- a/docs/dev-onboarding.md
+++ b/docs/dev-onboarding.md
@@ -45,6 +45,11 @@ All CDC modes publish into a shared `EventBus` (`src/engine/eventBus.ts`). The b
 2. Metrics updates (`onProduced`, `onConsumed`, `recordMissedDelete`, `recordWriteAmplification`) stay in sync with adapter semantics.
 3. UI consumers derive read models from the bus rather than bespoke stores—see `web/App.tsx` for integration examples.
 
+## Planning & status
+- Anchor every change against the implementation plan (currently **v1** per `docs/IMPLEMENTATION_PLAN.md`).
+- Before you start new work, skim the implementation plan’s [changelog](IMPLEMENTATION_PLAN.md#changelog) to see what shifted since your last sync.
+- Track active priorities and delivery gates via `docs/next-steps.md` and the feature-flag matrix in `docs/launch-readiness.md#feature-flag-matrix`.
+
 ## Common workflows
 - Review the day-to-day checklist in `../development.md` for the branching + PR process.
 - Run the React comparator + simulator side-by-side: `npm run dev:all` (spawns `npm run dev:sim` and `npm run dev:web` in parallel).

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -12,7 +12,7 @@ Each gate requires:
 - Harness verifier PASS against shared fixtures (`make status`).
 - Documentation updates reviewed via `docs/content-review-checklist.md`.
 
-### Rollout calendar
+### Feature flag matrix
 | Week | Audience | Flag state | Owner | Success signals |
 | --- | --- | --- | --- | --- |
 | Week 1 | Internal team accounts | `comparator_v2` forced **on** | Eng Enablement | Comparator smoke telemetry ≥ 5 sessions, no blocker bugs |


### PR DESCRIPTION
## Summary
- add a planning & status section to the developer onboarding guide that points to the implementation plan, its changelog, and ongoing status docs
- document the implementation plan changelog so onboarding references have an anchor
- label the launch readiness rollout table as the feature flag matrix referenced in onboarding

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68f86dcc8a988323b1eecac261479bec