### PR TITLE
Fix template literal in harness history script

### DIFF
--- a/scripts/summarize-harness-history.mjs
+++ b/scripts/summarize-harness-history.mjs
@@ -17,7 +17,7 @@ if (!TOKEN) {
 
 const headers = {
   Authorization: `Bearer ${TOKEN}`,
-  "User-Agent": `${REPO}-harness-history",
+  "User-Agent": `${REPO}-harness-history`,
   Accept: "application/vnd.github+json",
 };
 


### PR DESCRIPTION
## Summary
- correct the GitHub User-Agent header template literal in the harness history script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9144e38d083238b65de0f39b77a9a