### PR TITLE
Add in-memory table storage helper with tests

### DIFF
--- a/src/domain/storage.ts
+++ b/src/domain/storage.ts
@@ -1,0 +1,230 @@
+import type {
+  ColumnType,
+  Event,
+  Row,
+  Schema,
+  SchemaChange,
+  SchemaColumn,
+  Table,
+} from "./types";
+
+const cloneValue = <T>(value: T): T => {
+  if (Array.isArray(value)) {
+    return value.map(item => cloneValue(item)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const clone: Record<string, unknown> = {};
+    Object.entries(value as Record<string, unknown>).forEach(([key, val]) => {
+      clone[key] = cloneValue(val);
+    });
+    return clone as T;
+  }
+  return value;
+};
+
+const cloneRow = (row: Row): Row => cloneValue(row);
+
+const cloneSchemaColumn = (column: SchemaColumn): SchemaColumn => ({ ...column });
+
+const cloneSchema = (schema: Schema): Schema => ({
+  name: schema.name,
+  version: schema.version,
+  columns: schema.columns.map(cloneSchemaColumn),
+});
+
+const inferColumnType = (key: string, value: unknown): ColumnType => {
+  if (typeof value === "boolean") return "bool";
+  if (typeof value === "number") {
+    if (/_ts$|timestamp$/i.test(key)) return "timestamp";
+    return "number";
+  }
+  if (value instanceof Date) return "timestamp";
+  return "string";
+};
+
+type TableState = {
+  schema: Schema;
+  rows: Map<string, Row>;
+};
+
+const createEmptySchema = (tableName: string, version = 1): Schema => ({
+  name: tableName,
+  version,
+  columns: [
+    {
+      name: "id",
+      type: "string",
+      nullable: false,
+    },
+  ],
+});
+
+const ensureIdColumn = (schema: Schema) => {
+  const hasId = schema.columns.some(column => column.name === "id");
+  if (!hasId) {
+    schema.columns.unshift({ name: "id", type: "string", nullable: false });
+  }
+};
+
+const normaliseRow = (row: Row): Row => {
+  const clone = cloneRow(row);
+  clone.id = String(clone.id);
+  return clone;
+};
+
+export type StorageSnapshot = Table[];
+
+export class InMemoryTableStorage {
+  private readonly tables = new Map<string, TableState>();
+
+  constructor(initialTables: Table[] = []) {
+    initialTables.forEach(table => this.upsertTable(table));
+  }
+
+  upsertTable(table: Table): void {
+    const schema = cloneSchema(table.schema);
+    ensureIdColumn(schema);
+    const rows = new Map<string, Row>();
+    table.rows.forEach(row => {
+      const normalised = normaliseRow(cloneRow(row));
+      rows.set(normalised.id, normalised);
+    });
+    this.tables.set(table.name, { schema, rows });
+  }
+
+  replaceAll(tables: Table[]): void {
+    this.tables.clear();
+    tables.forEach(table => this.upsertTable(table));
+  }
+
+  getTable(name: string): Table | undefined {
+    const state = this.tables.get(name);
+    if (!state) return undefined;
+    return {
+      name,
+      schema: cloneSchema(state.schema),
+      rows: Array.from(state.rows.values()).map(row => cloneRow(row)),
+    };
+  }
+
+  listTables(): Table[] {
+    return Array.from(this.tables.keys())
+      .map(name => this.getTable(name))
+      .filter((table): table is Table => Boolean(table));
+  }
+
+  clear(): void {
+    this.tables.clear();
+  }
+
+  applyEvents(events: Event[]): void {
+    events.forEach(event => this.applyEvent(event));
+  }
+
+  applyEvent(event: Event): void {
+    if (!event?.table) return;
+    if (event.kind === "SCHEMA_ADD_COL" || event.kind === "SCHEMA_DROP_COL") {
+      this.applySchemaChange(event);
+      return;
+    }
+    const state = this.ensureTableState(event.table, event.schemaVersion);
+    if (event.schemaVersion && event.schemaVersion > state.schema.version) {
+      state.schema.version = event.schemaVersion;
+    }
+
+    if (event.kind === "DELETE") {
+      const id = event.before?.id ?? event.after?.id;
+      if (id != null) {
+        state.rows.delete(String(id));
+      }
+      return;
+    }
+
+    const payload = event.after ?? undefined;
+    if (!payload) return;
+    const normalised = normaliseRow(payload);
+    const existing = state.rows.get(normalised.id);
+    const mergedData = existing ? ({ ...existing, ...normalised } as Row) : normalised;
+    const merged = cloneRow(mergedData);
+    this.syncSchemaColumns(state, merged);
+    state.rows.set(merged.id, merged);
+  }
+
+  snapshot(): StorageSnapshot {
+    return this.listTables();
+  }
+
+  private ensureTableState(tableName: string, version?: number): TableState {
+    let state = this.tables.get(tableName);
+    if (!state) {
+      state = {
+        schema: createEmptySchema(tableName, version ?? 1),
+        rows: new Map<string, Row>(),
+      };
+      this.tables.set(tableName, state);
+    }
+    if (version && version > state.schema.version) {
+      state.schema.version = version;
+    }
+    ensureIdColumn(state.schema);
+    return state;
+  }
+
+  private applySchemaChange(event: Event & { schemaChange?: SchemaChange }): void {
+    const change = event.schemaChange;
+    if (!change) return;
+    const state = this.ensureTableState(event.table, change.nextVersion ?? event.schemaVersion);
+    state.schema.version = Math.max(
+      state.schema.version,
+      change.nextVersion ?? event.schemaVersion ?? state.schema.version,
+    );
+    if (event.kind === "SCHEMA_ADD_COL") {
+      this.addColumn(state, change.column);
+    } else if (event.kind === "SCHEMA_DROP_COL") {
+      this.dropColumn(state, change.column.name);
+    }
+  }
+
+  private addColumn(state: TableState, column: SchemaColumn): void {
+    const existing = state.schema.columns.find(col => col.name === column.name);
+    if (existing) {
+      existing.type = column.type;
+      if (column.nullable) existing.nullable = true;
+    } else {
+      state.schema.columns.push(cloneSchemaColumn(column));
+    }
+    state.rows.forEach(row => {
+      if (!(column.name in row)) {
+        row[column.name] = null;
+      }
+    });
+  }
+
+  private dropColumn(state: TableState, columnName: string): void {
+    if (columnName === "id") return;
+    state.schema.columns = state.schema.columns.filter(column => column.name !== columnName);
+    state.rows.forEach(row => {
+      if (columnName in row) {
+        delete row[columnName];
+      }
+    });
+  }
+
+  private syncSchemaColumns(state: TableState, row: Row): void {
+    const columns = state.schema.columns;
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === "id" || key.startsWith("__")) return;
+      let column = columns.find(col => col.name === key);
+      if (!column) {
+        column = {
+          name: key,
+          type: inferColumnType(key, value),
+        };
+        columns.push(column);
+      }
+      if (value == null) {
+        column.nullable = true;
+      }
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export * from "./engine/stateMachine";
 export * from "./modes";
 export * from "./features/presets";
 export * from "./features/scenarios";
+export * from "./domain/storage";
 export * from "./ui";

--- a/src/test/unit/storage.test.ts
+++ b/src/test/unit/storage.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryTableStorage } from "../../domain/storage";
+import type { Event, Table } from "../../domain/types";
+
+const makeEvent = (overrides: Partial<Event>): Event => ({
+  id: "evt-1",
+  kind: "INSERT",
+  table: "widgets",
+  commitTs: 0,
+  schemaVersion: 1,
+  topic: "cdc.widgets",
+  partition: 0,
+  ...overrides,
+});
+
+describe("InMemoryTableStorage", () => {
+  const baseTable: Table = {
+    name: "widgets",
+    schema: {
+      name: "widgets",
+      version: 1,
+      columns: [
+        { name: "id", type: "string" },
+        { name: "status", type: "string" },
+      ],
+    },
+    rows: [
+      { id: "w1", status: "seed", __ts: 10 },
+    ],
+  };
+
+  it("initialises with tables and clones snapshots", () => {
+    const storage = new InMemoryTableStorage([baseTable]);
+    const table = storage.getTable("widgets");
+    expect(table?.rows).toEqual(baseTable.rows);
+    expect(table?.schema.columns).toEqual(baseTable.schema.columns);
+
+    const firstRow = table?.rows[0];
+    if (!firstRow) throw new Error("missing row");
+    firstRow.status = "mutated";
+    const again = storage.getTable("widgets");
+    expect(again?.rows[0].status).toBe("seed");
+  });
+
+  it("applies insert, update, and delete events", () => {
+    const storage = new InMemoryTableStorage([baseTable]);
+
+    const insert = makeEvent({
+      id: "evt-insert",
+      kind: "INSERT",
+      commitTs: 20,
+      schemaVersion: 1,
+      after: { id: "w2", status: "new", flags: { retry: false } },
+    });
+    storage.applyEvent(insert);
+
+    const update = makeEvent({
+      id: "evt-update",
+      kind: "UPDATE",
+      commitTs: 40,
+      schemaVersion: 2,
+      after: { id: "w2", status: "ready", priority: true },
+    });
+    storage.applyEvent(update);
+
+    const drop = makeEvent({
+      id: "evt-delete",
+      kind: "DELETE",
+      commitTs: 60,
+      before: { id: "w2" },
+    });
+    storage.applyEvent(drop);
+
+    const table = storage.getTable("widgets");
+    expect(table?.rows.find(row => row.id === "w2")).toBeUndefined();
+    expect(table?.schema.version).toBe(2);
+    const statusColumn = table?.schema.columns.find(column => column.name === "status");
+    expect(statusColumn?.type).toBe("string");
+    const priorityColumn = table?.schema.columns.find(column => column.name === "priority");
+    expect(priorityColumn?.type).toBe("bool");
+  });
+
+  it("creates tables on demand and infers column types", () => {
+    const storage = new InMemoryTableStorage();
+    storage.applyEvent(
+      makeEvent({
+        table: "orders",
+        id: "evt-orders",
+        after: { id: "ord-1", total: 99.5, approved: false, processed_ts: 1200 },
+      }),
+    );
+
+    const table = storage.getTable("orders");
+    expect(table).toBeTruthy();
+    expect(table?.schema.columns.find(column => column.name === "total")?.type).toBe("number");
+    expect(table?.schema.columns.find(column => column.name === "approved")?.type).toBe("bool");
+    expect(table?.schema.columns.find(column => column.name === "processed_ts")?.type).toBe("timestamp");
+    expect(table?.rows[0].total).toBe(99.5);
+  });
+
+  it("handles schema change events and keeps rows in sync", () => {
+    const storage = new InMemoryTableStorage([baseTable]);
+
+    const addEvent: Event = makeEvent({
+      id: "evt-schema-add",
+      kind: "SCHEMA_ADD_COL",
+      schemaVersion: 2,
+      schemaChange: {
+        action: "ADD_COLUMN",
+        column: { name: "priority", type: "bool", nullable: true },
+        previousVersion: 1,
+        nextVersion: 2,
+      },
+    });
+    storage.applyEvent(addEvent);
+
+    const dropEvent: Event = makeEvent({
+      id: "evt-schema-drop",
+      kind: "SCHEMA_DROP_COL",
+      schemaVersion: 3,
+      schemaChange: {
+        action: "DROP_COLUMN",
+        column: { name: "status", type: "string" },
+        previousVersion: 2,
+        nextVersion: 3,
+      },
+    });
+    storage.applyEvent(dropEvent);
+
+    const table = storage.getTable("widgets");
+    expect(table?.schema.version).toBe(3);
+    expect(table?.schema.columns.some(column => column.name === "priority")).toBe(true);
+    expect(table?.schema.columns.some(column => column.name === "status")).toBe(false);
+    expect(table?.rows[0].priority).toBeNull();
+    expect("status" in (table?.rows[0] ?? {})).toBe(false);
+  });
+
+  it("returns deep clones from snapshots", () => {
+    const storage = new InMemoryTableStorage([baseTable]);
+    const snapshot = storage.snapshot();
+    expect(snapshot).toHaveLength(1);
+    const [table] = snapshot;
+    if (!table) throw new Error("missing table");
+    table.rows[0].status = "changed";
+    table.schema.columns.push({ name: "extra", type: "string" });
+
+    const fresh = storage.getTable("widgets");
+    expect(fresh?.rows[0].status).toBe("seed");
+    expect(fresh?.schema.columns.some(column => column.name === "extra")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce an in-memory table storage helper that can apply CDC events, schema changes, and produce deep-cloned snapshots for consumers
- export the storage helper from the shared entrypoint so simulator and comparator code can import it directly
- add a dedicated unit suite validating inserts, updates, deletes, schema changes, and cloning semantics of the storage helper

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f91c5ef7048323a3b0c26615d1ef76