### PR TITLE
Add destination snapshot export control

### DIFF
--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -755,21 +755,62 @@
 
 .sim-shell__destination > header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.sim-shell__destination-title {
+  display: flex;
+  align-items: baseline;
   gap: 0.5rem;
 }
 
-.sim-shell__destination > header h4 {
+.sim-shell__destination-title h4 {
   margin: 0;
   font-size: 0.95rem;
   color: #0f172a;
 }
 
-.sim-shell__destination > header span {
+.sim-shell__destination-title span {
   font-size: 0.75rem;
   color: #475569;
   font-weight: 600;
+}
+
+.sim-shell__destination-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sim-shell__destination-download {
+  font-size: 0.78rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+  cursor: pointer;
+  transition: transform 180ms cubic-bezier(0.2, 0.9, 0.2, 1),
+    box-shadow 180ms cubic-bezier(0.2, 0.9, 0.2, 1),
+    background-color 160ms ease;
+}
+
+.sim-shell__destination-download:hover:not([disabled]) {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(37, 99, 235, 0.12);
+}
+
+.sim-shell__destination-download:active:not([disabled]) {
+  transform: translateY(0) scale(0.985);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.sim-shell__destination-download:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .sim-shell__destination-table {


### PR DESCRIPTION
## Summary
- add an export handler so each comparator lane can download the applied destination tables as JSON
- update the destination snapshot header styling to support the new download action

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f9260300d483238e74f906c4479be0