### PR TITLE
Add event log replay action

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2556,6 +2556,16 @@ if (typeof window !== "undefined") {
       applyScenarioTemplate(template, { focusStep: "events" });
     }
   });
+  window.addEventListener("cdc:workspace-replay-event", event => {
+    if (!(event instanceof CustomEvent)) return;
+    const detail = event.detail;
+    if (!detail) return;
+    try {
+      replayEventToTable(detail);
+    } catch (err) {
+      console.warn("Replay to workspace failed", err);
+    }
+  });
   window.addEventListener("cdc:scenario-filter-request", () => {
     window.dispatchEvent(new CustomEvent("cdc:scenario-filter", { detail: { query: uiState.scenarioFilter, tags: uiState.scenarioTags } }));
   });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1652,7 +1652,8 @@ select:focus {
   text-align: right;
 }
 
-.cdc-event-log__copy {
+.cdc-event-log__copy,
+.cdc-event-log__replay {
   justify-self: end;
   font-size: 0.75rem;
   border: 1px solid rgba(94, 122, 185, 0.5);
@@ -1660,6 +1661,22 @@ select:focus {
   color: #cbd5f5;
   padding: 4px 8px;
   border-radius: 8px;
+}
+
+.cdc-event-log__copy,
+.cdc-event-log__replay {
+  margin-left: 6px;
+}
+
+.cdc-event-log__replay {
+  border-color: rgba(74, 222, 128, 0.4);
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+}
+
+.cdc-event-log__replay[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .cdc-event-log__empty,

--- a/src/test/unit/eventLog.test.tsx
+++ b/src/test/unit/eventLog.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { EventLog } from "../../ui/components/EventLog";
 
 const sampleEvent = {
@@ -26,5 +26,31 @@ describe("EventLog", () => {
     render(<EventLog events={[sampleEvent]} stats={{ produced: 2, consumed: 2, backlog: 1 }} />);
 
     expect(screen.queryByText(/Snapshot rows/)).not.toBeInTheDocument();
+  });
+
+  it("invokes the replay callback for change events", () => {
+    const onReplay = vi.fn();
+    render(
+      <EventLog
+        events={[{ ...sampleEvent, op: "c", methodId: "polling", table: "orders", pk: "ORD-1" }]}
+        onReplayEvent={onReplay}
+      />,
+    );
+
+    const replayButton = screen.getByRole("button", { name: "Replay" });
+    expect(replayButton).toBeEnabled();
+    fireEvent.click(replayButton);
+    expect(onReplay).toHaveBeenCalledTimes(1);
+    expect(onReplay).toHaveBeenCalledWith(expect.objectContaining({ id: sampleEvent.id }));
+  });
+
+  it("disables the replay action for schema events", () => {
+    const onReplay = vi.fn();
+    render(<EventLog events={[{ id: "evt-schema", op: "s" }]} onReplayEvent={onReplay} />);
+
+    const replayButton = screen.getByRole("button", { name: "Replay" });
+    expect(replayButton).toBeDisabled();
+    fireEvent.click(replayButton);
+    expect(onReplay).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/components/EventLog.tsx
+++ b/src/ui/components/EventLog.tsx
@@ -45,6 +45,7 @@ export type EventLogProps = {
   onDownload?: () => void;
   onClear?: () => void;
   onCopyEvent?: (event: EventLogRow) => void;
+  onReplayEvent?: (event: EventLogRow) => void;
   maxVisibleEvents?: number;
   emptyMessage?: string;
   noMatchMessage?: string;
@@ -91,6 +92,7 @@ export const EventLog: FC<EventLogProps> = ({
   onDownload,
   onClear,
   onCopyEvent,
+  onReplayEvent,
   maxVisibleEvents = DEFAULT_MAX_VISIBLE,
   emptyMessage,
   noMatchMessage,
@@ -257,6 +259,8 @@ export const EventLog: FC<EventLogProps> = ({
             const pk = event.pk ?? "—";
             const txn = event.txnId ?? "";
             const ts = typeof event.tsMs === "number" ? event.tsMs : "—";
+            const normalizedOp = typeof event.op === "string" ? event.op.trim().toLowerCase() : "";
+            const replayable = normalizedOp === "c" || normalizedOp === "u" || normalizedOp === "d";
             return (
               <li key={event.id} className="cdc-event-log__item">
                 <span className="cdc-event-log__method">
@@ -273,6 +277,16 @@ export const EventLog: FC<EventLogProps> = ({
                   {txn ? ` · txn=${txn}` : ""}
                 </span>
                 {event.meta ? <span className="cdc-event-log__extra">{event.meta}</span> : null}
+                {onReplayEvent ? (
+                  <button
+                    type="button"
+                    className="cdc-event-log__replay"
+                    onClick={() => onReplayEvent?.(event)}
+                    disabled={!replayable}
+                  >
+                    Replay
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="cdc-event-log__copy"

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1802,6 +1802,30 @@ export function App() {
     [scenario.name],
   );
 
+  const handleReplayEvent = useCallback(
+    (row: EventLogRow) => {
+      if (typeof window === "undefined") return;
+      const op = typeof row.op === "string" ? row.op.trim().toLowerCase() : "";
+      if (op !== "c" && op !== "u" && op !== "d") return;
+      const detail = {
+        op,
+        before: row.before ?? null,
+        after: row.after ?? null,
+        ts_ms: typeof row.tsMs === "number" ? row.tsMs : undefined,
+        table: row.table ?? undefined,
+        key: row.pk ? { id: row.pk } : undefined,
+      } as const;
+      window.dispatchEvent(new CustomEvent("cdc:workspace-replay-event", { detail }));
+      track("comparator.event.replay", {
+        scenario: scenario.name,
+        method: row.methodId ?? null,
+        table: row.table ?? null,
+        op,
+      });
+    },
+    [scenario.name],
+  );
+
   const handlePresetSelect = useCallback((value: string) => {
     if (!isVendorPresetId(value)) return;
     setPresetId(value);
@@ -2628,6 +2652,7 @@ export function App() {
           onDownload={handleDownloadEventLog}
           onClear={handleClearEventLog}
           onCopyEvent={handleCopyEvent}
+          onReplayEvent={handleReplayEvent}
           maxVisibleEvents={MAX_EVENT_LOG_ROWS}
         />
       )}

--- a/web/stories/EventLog.stories.tsx
+++ b/web/stories/EventLog.stories.tsx
@@ -76,6 +76,7 @@ const baseProps = {
   onDownload: () => console.info("Download NDJSON"),
   onClear: () => console.info("Clear events"),
   onCopyEvent: (event: EventLogRow) => console.info("Copy", event.id),
+  onReplayEvent: (event: EventLogRow) => console.info("Replay", event.id),
 };
 
 export const Populated = () => <EventLog {...baseProps} />;

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -1166,13 +1166,30 @@
 }
 
 .sim-shell__event-log-copy,
-.cdc-event-log__copy {
+.cdc-event-log__copy,
+.cdc-event-log__replay {
   font-size: 0.75rem;
   border: 1px solid rgba(100, 116, 139, 0.4);
   background: rgba(148, 163, 184, 0.12);
   color: #334155;
   padding: 0.25rem 0.5rem;
   border-radius: 8px;
+}
+
+.cdc-event-log__copy,
+.cdc-event-log__replay {
+  margin-left: 0.4rem;
+}
+
+.cdc-event-log__replay {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(22, 163, 74, 0.12);
+  color: #166534;
+}
+
+.cdc-event-log__replay[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .sim-shell__event-log-empty,


### PR DESCRIPTION
## Summary
- add an optional replay action to the shared EventLog component with matching styles
- wire the comparator shell to dispatch workspace replay events and record telemetry
- teach the legacy workspace script to consume replay events and expand unit coverage

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68f92876fcb48323a8be078e70659c11