### PR TITLE
Add scenario search and tag filtering to comparator header

### DIFF
--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -179,6 +179,63 @@
   color: #1f2937;
   font-size: 0.85rem;
 }
+.sim-shell__scenario-filter-row {
+  margin: 1rem 0 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+.sim-shell__scenario-search {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #334155;
+}
+.sim-shell__scenario-search input {
+  padding: 0.45rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  min-width: 240px;
+}
+.sim-shell__scenario-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+.sim-shell__scenario-tag {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.sim-shell__scenario-tag[data-active="true"] {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: #1d4ed8;
+}
+.sim-shell__scenario-tag:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+.sim-shell__scenario-tag--clear {
+  background: transparent;
+  border-style: dashed;
+  color: #64748b;
+}
+.sim-shell__scenario-tag--clear:hover {
+  background: rgba(148, 163, 184, 0.18);
+  color: #1f2937;
+}
+.sim-shell__scenario-tag--clear:focus-visible {
+  outline: 2px solid rgba(100, 116, 139, 0.4);
+  outline-offset: 2px;
+}
 .sim-shell__tag-row {
   display: flex;
   flex-wrap: wrap;
@@ -1343,6 +1400,14 @@
   .sim-shell__actions--scenario {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .sim-shell__scenario-filter-row {
+    align-items: stretch;
+  }
+
+  .sim-shell__scenario-search input {
+    width: 100%;
   }
 
   .sim-shell__event-filters {


### PR DESCRIPTION
## Summary
- add inline scenario search and tag toggles so comparator users can find demos faster
- broadcast updated filters to existing workspace integrations and persist telemetry
- style the new controls with responsive chip buttons matching the shell design

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa383165b08323b656ab18dbc4a87d