### PR TITLE
feat: persist scenario filter state across comparator sessions

### DIFF
--- a/src/features/scenarioFilters.ts
+++ b/src/features/scenarioFilters.ts
@@ -14,6 +14,144 @@ export type ScenarioFilterParams<T extends FilterableScenario> = {
   liveScenarioName?: string;
 };
 
+export type ScenarioFilterDetail = {
+  query: string;
+  tags: string[];
+};
+
+export interface ScenarioFilterStorage {
+  getItem(key: string): string | null | undefined;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export const SCENARIO_FILTER_STORAGE_KEY = "cdc_playground_template_filter_v1" as const;
+export const SCENARIO_FILTER_TAGS_STORAGE_KEY = "cdc_playground_template_filter_tags_v1" as const;
+
+export const DEFAULT_SCENARIO_FILTER: ScenarioFilterDetail = {
+  query: "",
+  tags: [],
+};
+
+const coerceScenarioFilterQuery = (query: string | null | undefined) =>
+  typeof query === "string" ? query : "";
+
+const coerceScenarioFilterTags = (tags: readonly string[] | null | undefined): string[] => {
+  if (!Array.isArray(tags)) return [];
+  const seen = new Set<string>();
+  const list: string[] = [];
+  tags.forEach(tag => {
+    if (tag == null) return;
+    const value = String(tag).trim();
+    if (!value || seen.has(value)) return;
+    seen.add(value);
+    list.push(value);
+  });
+  return list;
+};
+
+export const normaliseScenarioFilterDetail = (
+  detail: Partial<{ query?: unknown; tags?: unknown }> | null | undefined,
+): ScenarioFilterDetail => {
+  if (!detail || typeof detail !== "object") {
+    return { ...DEFAULT_SCENARIO_FILTER };
+  }
+
+  const query = coerceScenarioFilterQuery(typeof detail.query === "string" ? detail.query : "");
+  const tagsSource = detail.tags;
+
+  if (Array.isArray(tagsSource)) {
+    return { query, tags: coerceScenarioFilterTags(tagsSource as string[]) };
+  }
+
+  if (typeof tagsSource === "string") {
+    const trimmed = tagsSource.trim();
+    return { query, tags: trimmed ? [trimmed] : [] };
+  }
+
+  return { query, tags: [] };
+};
+
+export const scenarioFilterTagsEqual = (
+  a: readonly string[],
+  b: readonly string[],
+): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) return false;
+  }
+  return true;
+};
+
+export const scenarioFilterDetailsEqual = (
+  a: ScenarioFilterDetail,
+  b: ScenarioFilterDetail,
+): boolean => a.query === b.query && scenarioFilterTagsEqual(a.tags, b.tags);
+
+const normaliseStoredQuery = (value: string | null | undefined): string => {
+  if (typeof value !== "string") return "";
+  return value;
+};
+
+const normaliseStoredTags = (value: string | null | undefined): string[] => {
+  if (typeof value !== "string" || value.trim().length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return coerceScenarioFilterTags(parsed as string[]);
+    }
+  } catch {
+    // fall through to return []
+  }
+  return [];
+};
+
+export const loadScenarioFilterDetail = (
+  storage: ScenarioFilterStorage | null | undefined,
+): ScenarioFilterDetail => {
+  if (!storage) return { ...DEFAULT_SCENARIO_FILTER };
+  try {
+    const query = normaliseStoredQuery(storage.getItem(SCENARIO_FILTER_STORAGE_KEY));
+    const tags = normaliseStoredTags(storage.getItem(SCENARIO_FILTER_TAGS_STORAGE_KEY));
+    return { query, tags };
+  } catch {
+    return { ...DEFAULT_SCENARIO_FILTER };
+  }
+};
+
+export const saveScenarioFilterDetail = (
+  detail: ScenarioFilterDetail,
+  storage: ScenarioFilterStorage | null | undefined,
+): void => {
+  if (!storage) return;
+  const normalised = normaliseScenarioFilterDetail(detail);
+
+  try {
+    if (normalised.query) {
+      storage.setItem(SCENARIO_FILTER_STORAGE_KEY, normalised.query);
+    } else if (typeof storage.removeItem === "function") {
+      storage.removeItem(SCENARIO_FILTER_STORAGE_KEY);
+    } else {
+      storage.setItem(SCENARIO_FILTER_STORAGE_KEY, "");
+    }
+  } catch {
+    // ignore persistence errors for queries
+  }
+
+  try {
+    if (normalised.tags.length > 0) {
+      storage.setItem(SCENARIO_FILTER_TAGS_STORAGE_KEY, JSON.stringify(normalised.tags));
+    } else if (typeof storage.removeItem === "function") {
+      storage.removeItem(SCENARIO_FILTER_TAGS_STORAGE_KEY);
+    } else {
+      storage.setItem(SCENARIO_FILTER_TAGS_STORAGE_KEY, "");
+    }
+  } catch {
+    // ignore persistence errors for tags
+  }
+};
+
 const normaliseQuery = (query: string | null | undefined) =>
   typeof query === "string" ? query.trim().toLowerCase() : "";
 
@@ -102,8 +240,3 @@ export function collectScenarioTags<T extends FilterableScenario>(
   options.additionalTags?.forEach(tags => appendTags(tagSet, tags));
   return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
 }
-
-export type ScenarioFilterDetail = {
-  query: string;
-  tags: string[];
-};


### PR DESCRIPTION
## Summary
- add reusable scenario filter detail helpers for normalisation, storage, and comparisons
- persist comparator scenario filter query/tags to localStorage and respond to filter requests
- expand scenario filter unit coverage for normalisation and storage helpers

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fa47688508832384707064c41df691