### PR TITLE
Add lag aggregator support to metrics store

### DIFF
--- a/src/test/unit/metricsStore.test.ts
+++ b/src/test/unit/metricsStore.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { MetricsStore } from "../../engine/metrics";
+
+const createEvent = (commitTs: number) => ({ commitTs });
+
+describe("MetricsStore", () => {
+  it("tracks produced, consumed, backlog, and lag percentiles", () => {
+    const store = new MetricsStore();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(1_000);
+    store.onProduced([createEvent(100), createEvent(200)]);
+
+    nowSpy.mockReturnValue(1_500);
+    store.onConsumed([createEvent(500), createEvent(700)]);
+
+    const snapshot = store.snapshot();
+    expect(snapshot.produced).toBe(2);
+    expect(snapshot.consumed).toBe(2);
+    expect(snapshot.backlog).toBe(0);
+    expect(snapshot.lagMsP50).toBe(900);
+    expect(Math.round(snapshot.lagMsP95)).toBe(990);
+
+    nowSpy.mockRestore();
+  });
+
+  it("notifies lag aggregators on updates, reset, and supports unsubscribe", () => {
+    const store = new MetricsStore();
+    const aggregator = vi.fn();
+    const unsubscribe = store.registerLagAggregator(aggregator);
+
+    expect(aggregator).toHaveBeenCalledWith([]);
+    aggregator.mockClear();
+
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(2_000);
+    store.onConsumed([createEvent(500)]);
+    expect(aggregator).toHaveBeenCalledWith([1_500]);
+
+    aggregator.mockClear();
+    store.reset();
+    expect(aggregator).toHaveBeenCalledWith([]);
+
+    unsubscribe();
+    aggregator.mockClear();
+    store.onConsumed([createEvent(1_800)]);
+    expect(aggregator).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it("swallows aggregator errors so other callbacks still run", () => {
+    const store = new MetricsStore();
+    const bad = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const good = vi.fn();
+
+    store.registerLagAggregator(bad);
+    store.registerLagAggregator(good);
+
+    const nowSpy = vi.spyOn(Date, "now");
+    nowSpy.mockReturnValue(3_000);
+    expect(() => store.onConsumed([createEvent(2_000)])).not.toThrow();
+    expect(good).toHaveBeenCalledWith([1_000]);
+
+    nowSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add registration hooks in `MetricsStore` so lag aggregators receive updates and reset events
- ensure aggregator failures are isolated while preserving existing metrics calculations
- cover the metrics store with dedicated unit tests for aggregation behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68faac0fb20483239a710882f72922fe