### PR TITLE
Maintain autofill focus and splash feedback

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1666,6 +1666,35 @@ function emitSparkleTrail(op = "c") {
   }
 }
 
+function flashAutofillButton(button) {
+  if (!button) return;
+
+  const splash = document.createElement("span");
+  splash.className = "ops-button__splash";
+  if (isOfficeSchemaActive()) {
+    splash.dataset.office = "true";
+  }
+  button.appendChild(splash);
+
+  const cleanup = () => {
+    clearTimeout(fallback);
+    splash.remove();
+  };
+  const fallback = setTimeout(cleanup, 720);
+  splash.addEventListener("animationend", cleanup, { once: true });
+  splash.addEventListener("animationcancel", cleanup, { once: true });
+
+  if (typeof button.focus === "function") {
+    requestAnimationFrame(() => {
+      try {
+        button.focus({ preventScroll: true });
+      } catch {
+        button.focus();
+      }
+    });
+  }
+}
+
 function emitOfficeStaplerTrail() {
   const source = els.rowEditor;
   const target = els.eventLog;
@@ -4625,6 +4654,7 @@ function autofillRowAndInsert() {
     return;
   }
 
+  const triggerButton = els.autofillRow;
   const sample = generateSampleRow();
 
   // reflect values in the editor for transparency
@@ -4661,6 +4691,7 @@ function autofillRowAndInsert() {
   updateLearning("rows");
   emitSparkleTrail("c");
   if (isOfficeSchemaActive()) emitOfficeConfetti();
+  flashAutofillButton(triggerButton);
 }
 
 updateApplyPausedBanner(false, 0);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1378,6 +1378,43 @@ select:focus {
   flex-wrap: wrap;
 }
 
+.ops button {
+  position: relative;
+  overflow: hidden;
+}
+
+.ops button .ops-button__splash {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 180%;
+  height: 180%;
+  transform: translate(-50%, -50%) scale(0.35);
+  border-radius: 999px;
+  background: radial-gradient(circle at center, rgba(58, 184, 255, 0.42), rgba(58, 184, 255, 0));
+  opacity: 0;
+  pointer-events: none;
+  animation: ops-button-splash 480ms ease-out forwards;
+}
+
+.ops button .ops-button__splash[data-office="true"] {
+  background: radial-gradient(circle at center, rgba(255, 205, 112, 0.5), rgba(255, 205, 112, 0));
+}
+
+@keyframes ops-button-splash {
+  0% {
+    opacity: 0.9;
+    transform: translate(-50%, -50%) scale(0.35);
+  }
+  60% {
+    opacity: 0.45;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.1);
+  }
+}
+
 .export-actions {
   margin-top: 8px;
 }


### PR DESCRIPTION
## Summary
- keep the Autofill sample row control focused after inserting sample data
- add a splash animation that respects the Office easter egg styling while keeping sparkle/confetti effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fac140a3248323b28690bf9c0af054