### PR TITLE
Fix start-from-scratch blank schema behavior

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1159,10 +1159,7 @@ function applyScenarioTemplate(template, options = {}) {
   if (options.closeOnboarding) hideOnboarding(true);
 }
 
-function startFromScratch() {
-  const loadOffice = Boolean(els.onboardingEasterEgg?.checked);
-  setOfficeSchemaPreference(loadOffice);
-
+function resetWorkspaceState(loadOffice) {
   resetOfficeShenanigans({ resetMegadesk: true });
 
   if (loadOffice) {
@@ -1172,11 +1169,21 @@ function startFromScratch() {
     state.schema = [];
     state.scenarioId = null;
   }
+
   state.schemaVersion = 1;
   state.rows = [];
   state.events = [];
   state.remoteId = null;
   uiState.selectedEventIndex = null;
+  uiState.editorDraft = {};
+  uiState.editorTouched = {};
+}
+
+function startFromScratch() {
+  const loadOffice = Boolean(els.onboardingEasterEgg?.checked);
+  setOfficeSchemaPreference(loadOffice);
+
+  resetWorkspaceState(loadOffice);
 
   localStorage.removeItem(STORAGE_KEYS.lastTemplate);
   if (els.onboardingEasterEgg) els.onboardingEasterEgg.checked = false;

--- a/tests/e2e/workspace-onboarding.spec.mjs
+++ b/tests/e2e/workspace-onboarding.spec.mjs
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { pathToFileURL, fileURLToPath } from "url";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const indexUrl = pathToFileURL(path.resolve(__dirname, "../../index.html")).href;
+
+const suite = process.env.PLAYWRIGHT_DISABLE === "1" ? test.describe.skip : test.describe;
+
+async function loadWorkspace(page) {
+  await page.goto(indexUrl, { waitUntil: "load" });
+  await page.waitForSelector("#schema", { timeout: 15000 });
+}
+
+suite("Workspace onboarding", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+    });
+  });
+
+  test("start from scratch without Scranton seeds a blank schema", async ({ page }) => {
+    await loadWorkspace(page);
+
+    const overlay = page.locator("#onboardingOverlay");
+    await expect(overlay).toBeVisible({ timeout: 15000 });
+
+    const startButton = page.getByRole("button", { name: "Start from scratch" });
+    await expect(startButton).toBeVisible();
+    await startButton.click();
+
+    await expect(overlay).toBeHidden();
+
+    const schemaPills = page.locator("#schemaPills .pill");
+    await expect(schemaPills).toHaveCount(0);
+
+    await expect(page.locator("#schemaStatus")).toContainText("Add a column to begin");
+
+    const stored = await page.evaluate(() => window.localStorage.getItem("cdc_playground"));
+    expect(stored).toBeTruthy();
+    const parsed = stored ? JSON.parse(stored) : null;
+    expect(parsed?.schema ?? []).toHaveLength(0);
+    expect(parsed?.rows ?? []).toHaveLength(0);
+
+    const officePref = await page.evaluate(() => window.localStorage.getItem("cdc_playground_office_opt_in_v1"));
+    expect(officePref).toBe("false");
+  });
+});


### PR DESCRIPTION
## Summary
- add a resetWorkspaceState helper so start-from-scratch reliably clears schema, rows, and editor state
- keep the Scranton preference toggle but ensure the workspace re-renders as a blank schema when it is not selected
- add a Playwright onboarding test covering the start-from-scratch path without the Scranton easter egg

## Testing
- npm run test:e2e *(fails: Playwright browsers unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fac404a50c8323af51707b231998fe