### PR TITLE
Avoid blocking onboarding overlay on Appwrite init

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4420,6 +4420,16 @@ async function main() {
   broadcastComparatorState();
   setShareControlsEnabled(false);
 
+  const shouldShowOnboarding = !localStorage.getItem(STORAGE_KEYS.onboarding)
+    && (state.scenarioId === "default" || !state.schema.length)
+    && state.rows.length === 0
+    && state.events.length === 0;
+  const sharePending = Boolean(uiState.pendingShareId);
+
+  if (shouldShowOnboarding && !sharePending) {
+    maybeShowOnboarding();
+  }
+
   try {
     await initAppwrite();
     if (appwrite?.cfg?.scenarioCollectionId) setShareControlsEnabled(true);
@@ -4428,11 +4438,13 @@ async function main() {
     console.warn("Appwrite init skipped", err?.message || err);
   }
 
-  const shouldShowOnboarding = !localStorage.getItem(STORAGE_KEYS.onboarding)
-    && (state.scenarioId === "default" || !state.schema.length)
-    && state.rows.length === 0
-    && state.events.length === 0;
-  if (shouldShowOnboarding) maybeShowOnboarding();
+  if (shouldShowOnboarding && sharePending) {
+    const eligible = !localStorage.getItem(STORAGE_KEYS.onboarding)
+      && (state.scenarioId === "default" || !state.schema.length)
+      && state.rows.length === 0
+      && state.events.length === 0;
+    if (eligible) maybeShowOnboarding();
+  }
 }
 main();
 


### PR DESCRIPTION
## Summary
- show the onboarding overlay as soon as the local workspace qualifies instead of waiting for Appwrite network calls
- defer onboarding when loading a shared scenario and re-check once hydration finishes

## Testing
- npm run test:sim
- npm run test:e2e *(fails: Playwright browsers unavailable in container; Chromium download returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fac837f1f88323b3ca0fe5b26550a7