### PR TITLE
Add comparator reset control to clear runtime state

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -216,7 +216,7 @@ export type Metrics = {
 ## Performance Guardrails
 - Batch log rendering (windowed list). Cap EventLog to last N=2,000 events with "Load more".
 - Avoid heavy animations; prefer CSS transforms.
-- Provide "Reset simulation" to clear memory.
+- ✅ Provide "Reset simulation" to clear memory (playback controls now include a reset button that clears runtime state).
 
 ## Security/Privacy
 - No PII; generated sample data only.

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -2718,9 +2718,22 @@ export function App() {
   );
 
   const handleReset = useCallback(() => {
+    setEventSearch("");
+    setEventLogMethod(null);
+    setEventLogTable(null);
+    setEventLogOp(null);
+    setEventLogTxn("");
     resetRunnerState();
     trackClockControl("reset", { scenario: scenario.name });
-  }, [resetRunnerState, scenario.name]);
+  }, [
+    resetRunnerState,
+    scenario.name,
+    setEventLogMethod,
+    setEventLogOp,
+    setEventLogTable,
+    setEventLogTxn,
+    setEventSearch,
+  ]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -3177,6 +3190,9 @@ export function App() {
         </button>
         <button type="button" onClick={() => handleStep()}>
           Step +{STEP_MS}ms
+        </button>
+        <button type="button" onClick={handleReset}>
+          Reset
         </button>
         {pauseResumeEnabled && (
           <button


### PR DESCRIPTION
## Summary
- add a reset button to the comparator playback controls so users can clear the simulation state on demand
- clear event search and log filters whenever the reset action runs for a clean slate
- document that the reset control now ships as part of the performance guardrails

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fae5b300dc8323936a4dc89509e697