### PR TITLE
Document telemetry taxonomy and lane diff visual baselines

### DIFF
--- a/docs/enablement/lane-diff-visual-regression.md
+++ b/docs/enablement/lane-diff-visual-regression.md
@@ -1,0 +1,23 @@
+# Lane Diff Overlay – Visual Regression Notes
+
+The Ladle stories under `web/stories/LaneDiffOverlay.stories.tsx` capture the
+two canonical diff states we reference during reviews.
+
+## Stories to capture
+- **IssuesAndLag** – renders missing, extra, ordering issues alongside lag
+  samples. Use this for verifying copy, badges, and layout when a lane has
+  discrepancies.
+- **LagHotspots** – renders a lane with lag samples only. Use this to confirm
+  the lag-only callouts and charts remain legible when no issues are present.
+
+## Screenshot guidance
+1. Start Ladle with `npm run ladle`.
+2. Open each story and capture a full-card screenshot at 1280×720. Include the
+   lane header, totals, and lag table.
+3. Attach the images to QA checklists and launch reviews so stakeholders can
+   compare current visuals with the baselines.
+4. Update this document when new diff states or story variants are added.
+
+## File references
+- Stories: `web/stories/LaneDiffOverlay.stories.tsx`
+- Overlay component: `src/ui/components/LaneDiffOverlay.tsx`

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -31,8 +31,5 @@
 - Flesh out mode adapters with richer telemetry (write amplification, missed deletes) reflected in UI summaries. ✅ Lane checks panel now surfaces diff + lag chips; schema drift chips land in summary.
 - ✅ Replace placeholder `src/ui/components/EventLog` with the actual component now that the comparator pulls data from `/src` runtimes.
 - Add unit tests around `CDCController`, `EventBus`, and each mode adapter (see `src/test/README.md`). ✅ Vitest suite now covers adapters, controller, metrics, and lane overlays; continue expanding toward multi-table scenarios.
-- 📘 Add Storybook visual regression notes for lane checks / diff overlay so QA knows which Ladle stories to reference.
-  - Document the canonical states in `web/stories/LaneDiffOverlay.stories.tsx` (missing events, extra events, ordering, schema drift).
-  - During reviews, capture screenshots from Ladle (`npm run ladle`) using the "Diff Overlay / Summary" and "Diff Overlay / Details" stories.
-  - Attach the images to launch checklists so the enablement team can confirm copy and layout match the docs.
+- ✅ Add Storybook visual regression notes for lane checks / diff overlay so QA knows which Ladle stories to reference. See `docs/enablement/lane-diff-visual-regression.md` for the canonical story list and screenshot guidance.
 - ✅ Multi-table + transactional demo landed with apply-on-commit toggle; follow-up e2e for transaction drift still on backlog.

--- a/docs/telemetry-taxonomy.md
+++ b/docs/telemetry-taxonomy.md
@@ -6,10 +6,31 @@ The in-browser telemetry client buffers events to `localStorage` (`window.teleme
 | --- | --- | --- |
 | `comparator.scenario.select` | Activation | User picked a scenario from the comparator dropdown. Payload: `{ scenario, tags }` |
 | `comparator.scenario.preview` | Activation | Preview modal opened for a template. Payload: `{ scenario, tags }` |
+| `comparator.preset.select` | Activation | Vendor preset badge selected. Payload: `{ presetId }` |
+| `comparator.scenario.filter` | Activation | Scenario search input updated. Payload: `{ query }` |
+| `comparator.scenario.tag_toggle` | Funnel drop | Scenario tag chip toggled. Payload: `{ tag, active }` |
+| `comparator.scenario.tag_clear` | Funnel drop | Scenario tag filters cleared. No payload. |
 | `comparator.summary.copied` | Activation | Summary callouts copied to clipboard. Payload: `{ scenario, methods, tags }` |
 | `comparator.diff.opened` | Funnel drop | Lane diff details expanded. Payload: `{ method, issues, maxLag }` |
 | `comparator.overlay.inspect` | Activation | Lane checks CTA clicked; scrolls to diff details. Payload: `{ method, scenario }` |
+| `comparator.schema.change` | Activation | Schema walkthrough action taken. Payload: `{ method, action, column, scenario }` |
 | `comparator.clock.control` | Funnel drop | Guided clock control action (`play`, `pause`, `seek`, `step`, `reset`). Payload: `{ action, scenario, deltaMs? }` |
+| `comparator.consumer.toggle` | Funnel drop | Pause/resume apply. Payload: `{ scenario, paused }` |
+| `comparator.consumer.rate_toggle` | Funnel drop | Throughput limiter toggle clicked. Payload: `{ scenario, enabled }` |
+| `comparator.consumer.rate_adjust` | Activation | Throughput limiter slider changed. Payload: `{ scenario, rate }` |
+| `comparator.consumer.rate_reset` | Activation | Throughput limiter reset to default. Payload: `{ scenario }` |
+| `comparator.event.search` | Activation | Event log search query changed. Payload: `{ scenario, query, hasQuery }` |
+| `comparator.event.filter` | Activation | Event operation pill toggled. Payload: `{ scenario, op, active }` |
+| `comparator.panel.layout` | Adoption | Event timeline shown/hidden. Payload: `{ scenario, showEvents }` |
+| `comparator.event.download` | Adoption | Event log exported as NDJSON. Payload: `{ scenario, events }` |
+| `comparator.event.clear` | Adoption | Event log cleared. Payload: `{ scenario }` |
+| `comparator.event.copy` | Activation | Event copied to clipboard. Payload: `{ scenario, method, table, op }` |
+| `comparator.event.copy.error` | Quality gate | Clipboard copy failed. Payload: `{ scenario, reason }` |
+| `comparator.event.replay` | Activation | Event replayed into workspace. Payload: `{ scenario, method, op, pk }` |
+| `comparator.destination.download` | Adoption | Destination snapshot downloaded. Payload: `{ scenario, method, tables }` |
+| `comparator.generator.toggle` | Adoption | Generator toggled on/off. Payload: `{ scenario, enabled }` |
+| `comparator.generator.rate_adjust` | Adoption | Generator cadence changed. Payload: `{ scenario, rate }` |
+| `comparator.generator.burst` | Activation | Burst run triggered. Payload: `{ scenario, count, spacingMs }` |
 | `tour.started` | Funnel drop | Spotlight walkthrough initiated. Payload: `{ totalSteps, source }` |
 | `tour.completed` | Activation | Spotlight completed. Payload: `{ totalSteps, durationMs }` |
 | `tour.dismissed` | Funnel drop | Spotlight exited before completion. Payload: `{ totalSteps, durationMs, step, reason }` |


### PR DESCRIPTION
## Summary
- document newly instrumented comparator telemetry events, including event log, generator, and rate controls
- add a lane diff overlay visual regression guide under docs/enablement and link it from the next-steps tracker

## Testing
- npm run test:sim
- npm run test:unit
- npm run test:harness-report
- npm run test:e2e *(fails: Playwright browsers not installed in CI runner)*

------
https://chatgpt.com/codex/tasks/task_e_68faedde43048323b3e8bb7ca2792a74