### PR TITLE
Support multi-term scenario filter queries

### DIFF
--- a/src/features/scenarioFilters.ts
+++ b/src/features/scenarioFilters.ts
@@ -192,6 +192,10 @@ export function applyScenarioFilters<T extends FilterableScenario>(
 
   const requiredTags = normaliseTags(tags);
   const normalizedQuery = normaliseQuery(query);
+  const queryTokens = normalizedQuery
+    .split(/\s+/)
+    .map(token => token.trim())
+    .filter(token => token.length > 0);
 
   return list.filter(option => {
     if (liveScenarioName && option.name === liveScenarioName) {
@@ -204,11 +208,11 @@ export function applyScenarioFilters<T extends FilterableScenario>(
       if (!hasAllTags) return false;
     }
 
-    if (!normalizedQuery) return true;
+    if (queryTokens.length === 0) return true;
 
     const haystack = buildHaystack(option);
     if (!haystack) return false;
-    return haystack.includes(normalizedQuery);
+    return queryTokens.every(token => haystack.includes(token));
   });
 }
 

--- a/src/test/unit/scenarioFilters.test.ts
+++ b/src/test/unit/scenarioFilters.test.ts
@@ -203,6 +203,20 @@ describe("applyScenarioFilters", () => {
     expect(result.map(option => option.id)).toEqual(["orders"]);
   });
 
+  it("requires all query terms to appear in the scenario metadata", () => {
+    const multiMatch = applyScenarioFilters(baseScenarios, {
+      query: "lag hotspots",
+    });
+
+    expect(multiMatch.map(option => option.id)).toEqual(["orders"]);
+
+    const noMatch = applyScenarioFilters(baseScenarios, {
+      query: "lag payments",
+    });
+
+    expect(noMatch).toHaveLength(0);
+  });
+
   it("filters scenarios by requiring all selected tags", () => {
     const result = applyScenarioFilters(baseScenarios, {
       tags: ["lag", "orders"],


### PR DESCRIPTION
## Summary
- allow scenario filters to tokenize the search query and require every term to be present in the scenario metadata
- add unit tests covering multi-term query matching behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68fbe7738cd083239d0df9354789faf0