### PR TITLE
Remove Slack notification from nightly harness workflow

### DIFF
--- a/.github/workflows/harness-nightly.yml
+++ b/.github/workflows/harness-nightly.yml
@@ -33,23 +33,3 @@ jobs:
         with:
           name: harness-report
           path: artifacts
-      - name: Notify Slack
-        if: always()
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "text": "Harness Nightly run *${{ github.run_number }}* for `${{ github.ref_name }}` ${JOB_STATUS} | <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>",
-              "attachments": [
-                {
-                  "color": "${{ job.status == 'success' && '#15803d' || '#b91c1c' }}",
-                  "fields": [
-                    { "title": "Status", "value": "${JOB_STATUS}", "short": true },
-                    { "title": "Scenario", "value": "orders-transactions", "short": true }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          JOB_STATUS: ${{ job.status }}


### PR DESCRIPTION
## Summary
- remove the Slack notification step from the Harness Nightly GitHub Actions workflow

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ffc078b4848323be027f7aab1d8a8c