### PR TITLE
Restore default scenario id when loading default schema

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1506,6 +1506,9 @@ const load   = () => {
     state.schemaVersion = Number(s.schemaVersion) || 1;
     state.scenarioId = s.scenarioId || null;
     state.remoteId = s.remoteId || null;
+    if (!state.scenarioId && state.schema.length && isOfficeSchemaActive()) {
+      state.scenarioId = "default";
+    }
   } catch { /* ignore */ }
 };
 const loadTemplateFilter = () => {


### PR DESCRIPTION
## Summary
- ensure that persisted workspaces with the stock Scranton schema regain the `default` scenario id when rehydrated
- guarantees onboarding logic still treats a regenerated office template as eligible for the welcome overlay

## Testing
- npm run test:e2e *(fails: Playwright could not download required browsers in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffccfba81c83238788e3cd895c77a4