### PR TITLE
Fix onboarding overlay initialization crash

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4468,13 +4468,13 @@ async function main() {
   broadcastComparatorState();
   setShareControlsEnabled(false);
 
-  const shouldShowOnboarding = !localStorage.getItem(STORAGE_KEYS.onboarding)
+  const shouldShowOnboardingNow = !localStorage.getItem(STORAGE_KEYS.onboarding)
     && (state.scenarioId === "default" || !state.schema.length)
     && state.rows.length === 0
     && state.events.length === 0;
   const sharePending = Boolean(uiState.pendingShareId);
 
-  if (shouldShowOnboarding && !sharePending) {
+  if (shouldShowOnboardingNow && !sharePending) {
     maybeShowOnboarding();
   }
 


### PR DESCRIPTION
## Summary
- rename the onboarding visibility flag inside `main` to avoid shadowing the `shouldShowOnboarding` helper
- allow the onboarding overlay to become visible again on first load instead of crashing at runtime

## Testing
- npm run test:e2e -- workspace-onboarding *(fails: Playwright browsers not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffcf5a0b248323b48de934bf9a3b14