### PR TITLE
Ensure onboarding overlay can be reset for tests

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -147,6 +147,15 @@ function createSafeStorage() {
 
 const storage = createSafeStorage();
 
+if (typeof window !== "undefined") {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("resetOnboarding")) {
+      storage.remove(STORAGE_KEYS.onboarding);
+    }
+  } catch { /* ignore */ }
+}
+
 const COMPARATOR_PREFS_KEY = "cdc_comparator_prefs_v1";
 const SCHEMA_DEMO_COLUMN = { name: "priority_flag", type: "boolean" };
 

--- a/tests/e2e/workspace-onboarding.spec.mjs
+++ b/tests/e2e/workspace-onboarding.spec.mjs
@@ -4,7 +4,9 @@ import path from "path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const indexUrl = pathToFileURL(path.resolve(__dirname, "../../index.html")).href;
+const indexFileUrl = pathToFileURL(path.resolve(__dirname, "../../index.html"));
+indexFileUrl.searchParams.set("resetOnboarding", "1");
+const indexUrl = indexFileUrl.href;
 
 const suite = process.env.PLAYWRIGHT_DISABLE === "1" ? test.describe.skip : test.describe;
 


### PR DESCRIPTION
## Summary
- allow resetting the onboarding state when `resetOnboarding` is present in the URL
- load the onboarding E2E spec against the reset URL so the overlay reliably appears for the test

## Testing
- not run (Playwright browser download blocked in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ffe766b7e08323959e104b82b2e53d