### PR TITLE
docs: add backlog issue catalog

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -57,7 +57,7 @@ pgsql
 
 ### Storage integration (Deferred)
 - **Status**: Deferred until external dependencies are ready.
-- **Remaining work**: implement the domain `storage.ts` helper to persist source/destination tables between refreshes and add the optional Appwrite-backed persistence layer/configuration hooks.
+- **Remaining work**: implement the domain `storage.ts` helper to persist source/destination tables between refreshes and add the optional Appwrite-backed persistence layer/configuration hooks. Track via [docs/issues/appwrite-persistence.md](./issues/appwrite-persistence.md).
 - **Prerequisites/blockers**:
   - Confirm the data model and interface for the storage helper so it matches upcoming engine/state machine expectations.
   - Provision an Appwrite project (API keys, self-hosted endpoint) and decide on authentication + data retention policies for demo data.
@@ -146,7 +146,7 @@ export type Metrics = {
 
 6. **Trigger-based CDC mode (P1)**
    - Adapter skeleton implemented; emits events with configurable trigger overhead and increments write amplification metric.
-   - Next: surface write amplification in UI and integrate into guided walkthrough.
+   - Next: surface write amplification in UI and integrate into guided walkthrough. See [docs/issues/trigger-write-amplification.md](./issues/trigger-write-amplification.md).
 
 7. **Schema change demo (P1)**
    - ✅ Buttons: Add Column, Drop Column on Source.
@@ -227,7 +227,7 @@ export type Metrics = {
 ## Rollout Plan
 - Feature flags: `ff_event_bus`, `ff_pause_resume`, `ff_query_slider`, `ff_trigger_mode`, `ff_schema_demo`, `ff_multitable`, `ff_metrics`, `ff_walkthrough`.
 - Release order: P0 bundle (event bus, pause/resume, query slider, CRUD fix, EventLog) -> P1 (trigger mode, schema demo, multitable, metrics, walkthrough, presets) -> P2 (generator, replay, second consumer).
-- Track owners, default states, and activation sequencing in [`docs/feature-flags.md`](./feature-flags.md).
+- Track owners, default states, and activation sequencing in [`docs/feature-flags.md`](./feature-flags.md); open governance tasks live in [docs/issues/feature-flag-governance.md](./issues/feature-flag-governance.md).
 - Add `CHANGELOG.md`.
 
 ## Acceptance Criteria (summarized)

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,6 +1,6 @@
 # Feature Flag Matrix
 
-This matrix tracks the major feature flags used in the CDC playground, summarising ownership, intent, defaults, and rollout sequencing so teams can coordinate launches and support.
+This matrix tracks the major feature flags used in the CDC playground, summarising ownership, intent, defaults, and rollout sequencing so teams can coordinate launches and support. Outstanding governance work is tracked in [docs/issues/feature-flag-governance.md](./issues/feature-flag-governance.md).
 
 | Flag | Owner | Purpose | Default State | Rollout Plan |
 | --- | --- | --- | --- | --- |

--- a/docs/issues/appwrite-persistence.md
+++ b/docs/issues/appwrite-persistence.md
@@ -1,0 +1,24 @@
+# Issue: Appwrite-backed persistence for scenarios and telemetry
+
+## Summary
+Implement persistent storage powered by Appwrite so that simulator scenarios, configuration, and comparator telemetry survive page reloads and can be shared across sessions.
+
+## Motivation
+The playground currently relies on in-memory helpers, preventing users from saving progress or collecting long-lived metrics. Shipping persistence unblocks roadmap items such as shared scenarios and reliable telemetry review.
+
+## Task Checklist
+- [ ] Evaluate Appwrite collections for storing scenarios, presets, and session telemetry; document required schemas.
+- [ ] Add client configuration + environment wiring (local `.env`, production secrets) with clear onboarding docs.
+- [ ] Implement persistence adapters in the simulator/comparator to read/write scenarios and telemetry through Appwrite.
+- [ ] Update feature flags or guards to expose persistence-backed flows behind a controllable rollout flag.
+- [ ] Extend unit/integration coverage to cover persistence adapters and fallback behaviour when Appwrite is unavailable.
+- [ ] Refresh docs (README, `docs/next-steps.md`, onboarding) with persistence setup and troubleshooting guidance.
+
+## Testing Notes
+- Run existing unit + e2e suites to ensure no regression (`npm run test:unit`, `npm run test:e2e`).
+- Add targeted integration smoke that exercises save/load flows against a local Appwrite instance.
+
+## Related Resources
+- `src/features/scenarios.ts` (scenario gallery definitions)
+- `src/engine/metricsStore.ts` (telemetry buffer)
+- `docs/next-steps.md` (outstanding persistence note)

--- a/docs/issues/comparator-v2-rollout.md
+++ b/docs/issues/comparator-v2-rollout.md
@@ -1,0 +1,23 @@
+# Issue: Complete `comparator_v2` staged rollout readiness
+
+## Summary
+Finish the launch readiness work for the `comparator_v2` flag by walking through the staged rollout gates, validating CI health, and preparing communications/rollback materials.
+
+## Motivation
+Launch readiness notes highlight outstanding tasks before GA. Documenting them as an issue ensures we track internal dogfood, beta cohort validation, GA approval, and accompanying comms.
+
+## Task Checklist
+- [ ] Re-run CI preflight (`npm run ci:preflight`) and ensure Playwright + harness checks are green.
+- [ ] Execute the internal dogfood gate: enable the flag for team accounts, collect telemetry, and log findings.
+- [ ] Prepare beta cohort allowlist + support macros; monitor activation + retention metrics.
+- [ ] Draft and review GA communications (release notes, Loom walkthrough, support macros) and confirm rollback plan.
+- [ ] Capture rollout outcomes + links in `docs/launch-readiness.md` and update status.
+- [ ] Decide on flag default-on timing and document governance plan post-launch.
+
+## Testing Notes
+- Full CI preflight and any manual smoke required for staged rollout sign-off.
+
+## Related Resources
+- `docs/launch-readiness.md`
+- `docs/enablement/release-notes.md`
+- `.github/workflows/preflight.yml`

--- a/docs/issues/feature-flag-governance.md
+++ b/docs/issues/feature-flag-governance.md
@@ -1,0 +1,22 @@
+# Issue: Plan feature flag activation sequencing & telemetry validation
+
+## Summary
+Define the activation plan for remaining feature flags (`ff_trigger_mode`, `ff_schema_demo`, `ff_multitable`, `ff_metrics`, `ff_walkthrough`) and wire telemetry checks to confirm safe rollout.
+
+## Motivation
+Multiple P1 flags remain default-off pending launch timing. Establishing sequencing, telemetry dashboards, and rollback criteria ensures smooth enablement across cohorts.
+
+## Task Checklist
+- [ ] Inventory each flag’s current default, dependencies, and UI coverage.
+- [ ] Define activation cohorts and timing, aligning with launch readiness + product milestones.
+- [ ] Implement telemetry logging/dashboards to monitor adoption, errors, and opt-outs per flag.
+- [ ] Document rollback procedures and support macros for each flag.
+- [ ] Update `docs/feature-flags.md` and related enablement material with the finalized governance plan.
+
+## Testing Notes
+- Validate telemetry hooks locally (unit tests if possible) and confirm dashboards receive events in staging.
+
+## Related Resources
+- `docs/feature-flags.md`
+- `docs/launch-readiness.md`
+- Telemetry implementation under `src/engine/metrics`

--- a/docs/issues/ops-sync.md
+++ b/docs/issues/ops-sync.md
@@ -1,0 +1,22 @@
+# Issue: Operational sync on ownership, sprint board, and review cadence
+
+## Summary
+Close the open operational chores by confirming workstream ownership, updating the sprint board, and scheduling the mid-sprint review demo.
+
+## Motivation
+Project tracking still lists these items as pending (🔄). Resolving them keeps stakeholders aligned and ensures upcoming demos and launches have coverage.
+
+## Task Checklist
+- [ ] Confirm or assign owners for each P0 workstream and document them in the tracker (`docs/next-steps.md`).
+- [ ] Audit the sprint board, reflect shipped feature flags, and move completed stories to Done.
+- [ ] Schedule the mid-sprint review meeting with agenda covering Event Log, Pause/Resume, Query warnings, and trigger follow-up.
+- [ ] Share meeting invite + prep materials (demo script, checkpoints) with cross-functional partners.
+- [ ] Update documentation or status notes with confirmed ownership and meeting details.
+
+## Testing Notes
+- No code changes expected; verify documentation updates render correctly and links remain valid.
+
+## Related Resources
+- `docs/next-steps.md`
+- Sprint board link (add/update in README if missing)
+- `docs/enablement/loom-plan.md` for demo talking points

--- a/docs/issues/shareable-experiences.md
+++ b/docs/issues/shareable-experiences.md
@@ -1,0 +1,24 @@
+# Issue: Persistent scenarios & shareable experience enhancements
+
+## Summary
+Deliver the longer-term roadmap items around persistent scenarios, Appwrite realtime sync, and shareable links for comparator sessions.
+
+## Motivation
+These enhancements extend the playground beyond single-session demos, enabling teams to collaborate asynchronously and embed guided tours in documentation.
+
+## Task Checklist
+- [ ] Prototype Appwrite realtime sync to broadcast scenario changes across clients.
+- [ ] Design persistent scenario model (naming, access control) and implement CRUD flows in the simulator/comparator.
+- [ ] Add deep-link/shareable URLs that encode scenario + flag state, with validation for stale links.
+- [ ] Update UI affordances (save/share buttons, toasts) with accessibility considerations.
+- [ ] Document new capabilities in README, docs/enablement materials, and support macros.
+- [ ] Evaluate telemetry to measure adoption and gather feedback for follow-up iterations.
+
+## Testing Notes
+- Extend unit + E2E suites to cover save/share flows.
+- Add integration smoke for realtime sync (multi-client simulation) if feasible.
+
+## Related Resources
+- `docs/next-steps.md`
+- `src/features/scenarios.ts`
+- `assets/app.js` (bootstrap + flag wiring)

--- a/docs/issues/transaction-drift-e2e.md
+++ b/docs/issues/transaction-drift-e2e.md
@@ -1,0 +1,23 @@
+# Issue: Add end-to-end coverage for transaction drift scenario
+
+## Summary
+Create an automated end-to-end test that validates transaction drift handling in the multi-table demo, ensuring apply-on-commit behaviour stays correct.
+
+## Motivation
+Although the multi-table + transactions demo shipped, the follow-up E2E test remains on the backlog. Automating it protects against regressions in commit-order handling and diff overlays.
+
+## Task Checklist
+- [ ] Define the transaction drift scenario steps (generator data, expected lane diffs) and capture them as fixtures.
+- [ ] Extend Playwright or harness-based tests to execute the scenario, including toggling apply-on-commit and validating UI indicators.
+- [ ] Add assertions for event ordering, lag metrics, and diff overlays specific to transaction drift.
+- [ ] Ensure the test runs in CI preflight and document runtime considerations.
+- [ ] Update documentation summarizing the new automated coverage and how to run it locally.
+
+## Testing Notes
+- Run `npm run test:e2e` locally to confirm the new test passes.
+- If using harness workflow, also run `npm run ci:harness` or the specific make target referenced in docs.
+
+## Related Resources
+- `tests/e2e` Playwright suite
+- `sim/` generator fixtures
+- `docs/next-steps.md` (transaction drift backlog reference)

--- a/docs/issues/trigger-write-amplification.md
+++ b/docs/issues/trigger-write-amplification.md
@@ -1,0 +1,25 @@
+# Issue: Surface trigger write amplification insights in UI & walkthrough
+
+## Summary
+Expose trigger-based CDC write amplification metrics in the comparator UI and integrate the insights into the guided walkthrough so users understand the operational trade-offs.
+
+## Motivation
+The trigger mode adapter already captures write amplification metadata, but the UI does not surface it. Highlighting the cost in both dashboards and the walkthrough keeps the demo accurate and educational.
+
+## Task Checklist
+- [ ] Audit trigger mode metrics emitted from `src/modes/triggerBased.ts` and confirm write amplification counters are available.
+- [ ] Design UI presentation for amplification (metrics strip, tooltips, or dedicated panel) and update components under `src/ui/components` accordingly.
+- [ ] Extend the guided walkthrough content to call out write amplification implications for trigger mode.
+- [ ] Gate the new visuals/content behind the relevant feature flag (`ff_trigger_mode`) and ensure sensible fallbacks when disabled.
+- [ ] Add unit + story coverage for the new UI surfaces and extend Playwright smoke to validate walkthrough updates.
+- [ ] Refresh docs (feature flags, release notes, enablement collateral) describing the new insight.
+
+## Testing Notes
+- `npm run test:unit` for component coverage.
+- `npm run test:e2e` to confirm walkthrough + UI flows.
+- Update or add Ladle stories for the new metrics presentation and capture visual references.
+
+## Related Resources
+- `src/modes/triggerBased.ts`
+- `src/ui/components/MetricsStrip.tsx` and related dashboards
+- `docs/enablement/loom-plan.md`, `docs/next-steps.md`

--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -1,5 +1,7 @@
 # Launch Readiness Plan
 
+Follow the tracked tasks in [docs/issues/comparator-v2-rollout.md](./issues/comparator-v2-rollout.md) to complete the staged rollout.
+
 ## Feature flag rollout
 1. **Internal dogfood** (`comparator_v2` enabled for team accounts only).
 2. **Beta cohort** (handful of customers opted in via support macros).

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -19,17 +19,25 @@
 
 ## Definition of Ready
 - Implementation plan captured at `docs/IMPLEMENTATION_PLAN.md` and linked in team tooling. ✅
-- Owners identified for each P0 workstream; story tickets created with acceptance criteria above. 🔄 Confirm assignment.
+- Owners identified for each P0 workstream; story tickets created with acceptance criteria above. 🔄 Confirm assignment. See [docs/issues/ops-sync.md](./issues/ops-sync.md).
 - UI copy agreed for warning/info badges and pause help text; visual mocks shared with design partners. ✅
 - Test data scenarios scripted (rapid updates, delete between polls) and automated where feasible. ✅ (scenarios in `src/features/scenarios.ts`).
 
 ## Tracking
-- Capture progress in the sprint board using the P0 feature flags as epics. 🔄 Update board to reflect shipped flags.
-- Schedule mid-sprint review to demo Event Log, Pause/Resume, and Query mode warning behaviors. 🔄
+- Capture progress in the sprint board using the P0 feature flags as epics. 🔄 Update board to reflect shipped flags. Tracked in [docs/issues/ops-sync.md](./issues/ops-sync.md).
+- Schedule mid-sprint review to demo Event Log, Pause/Resume, and Query mode warning behaviors. 🔄 Included in [docs/issues/ops-sync.md](./issues/ops-sync.md).
 
 ## Near-Term Priorities (handoff)
 - Flesh out mode adapters with richer telemetry (write amplification, missed deletes) reflected in UI summaries. ✅ Lane checks panel now surfaces diff + lag chips; schema drift chips land in summary.
 - ✅ Replace placeholder `src/ui/components/EventLog` with the actual component now that the comparator pulls data from `/src` runtimes.
 - Add unit tests around `CDCController`, `EventBus`, and each mode adapter (see `src/test/README.md`). ✅ Vitest suite now covers adapters, controller, metrics, and lane overlays; continue expanding toward multi-table scenarios.
 - ✅ Add Storybook visual regression notes for lane checks / diff overlay so QA knows which Ladle stories to reference. See `docs/enablement/lane-diff-visual-regression.md` for the canonical story list and screenshot guidance.
-- ✅ Multi-table + transactional demo landed with apply-on-commit toggle; follow-up e2e for transaction drift still on backlog.
+- ✅ Multi-table + transactional demo landed with apply-on-commit toggle; follow-up e2e for transaction drift still on backlog. See [docs/issues/transaction-drift-e2e.md](./issues/transaction-drift-e2e.md).
+
+## Outstanding backlog
+- [ ] Appwrite persistence + configuration ([docs/issues/appwrite-persistence.md](./issues/appwrite-persistence.md))
+- [ ] Trigger write amplification surfaced in UI/walkthrough ([docs/issues/trigger-write-amplification.md](./issues/trigger-write-amplification.md))
+- [ ] Operational sync on owners + mid-sprint review ([docs/issues/ops-sync.md](./issues/ops-sync.md))
+- [ ] `comparator_v2` staged rollout readiness ([docs/issues/comparator-v2-rollout.md](./issues/comparator-v2-rollout.md))
+- [ ] Feature flag activation governance ([docs/issues/feature-flag-governance.md](./issues/feature-flag-governance.md))
+- [ ] Persistent scenarios & shareable experiences ([docs/issues/shareable-experiences.md](./issues/shareable-experiences.md))


### PR DESCRIPTION
## Summary
- capture each outstanding follow-up from the v1 status review as a dedicated markdown issue under docs/issues
- link existing planning docs (implementation plan, next steps, feature flags, launch readiness) to the new issue stubs
- surface a consolidated outstanding backlog checklist in docs/next-steps.md for easy navigation

## Plan
1. Create issue markdown files describing scope, motivation, tasks, and testing guidance for each outstanding work item.
2. Update planning documentation to reference the corresponding issue files.
3. Summarise the backlog list in docs/next-steps.md.

## Changes
- docs/issues/*
- docs/IMPLEMENTATION_PLAN.md
- docs/feature-flags.md
- docs/launch-readiness.md
- docs/next-steps.md

## Verification
Commands:
```
(none)
```
Evidence:
- Documentation-only update; no runtime impact.

## Risks & Mitigations
- Backlog docs could drift from reality → Keep issue files updated as work progresses.

## Follow-ups
- Execute the newly filed issues in priority order.


------
https://chatgpt.com/codex/tasks/task_e_6906699675648323bb07dcabf63d2e51