### PR TITLE
feat(web): surface trigger amplification insight

### DIFF
--- a/src/test/unit/writeAmplificationChip.test.ts
+++ b/src/test/unit/writeAmplificationChip.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatWriteAmplificationChip } from "../../../web/App";
+
+describe("formatWriteAmplificationChip", () => {
+  it("returns null for non-positive values", () => {
+    expect(formatWriteAmplificationChip(0)).toBeNull();
+    expect(formatWriteAmplificationChip(-1)).toBeNull();
+    expect(formatWriteAmplificationChip(Number.NaN)).toBeNull();
+  });
+
+  it("formats amplification values with a single decimal place", () => {
+    const chip = formatWriteAmplificationChip(2.456);
+    expect(chip).not.toBeNull();
+    expect(chip).toEqual({
+      key: "write-amplification",
+      text: "2.5x write amplification",
+      tone: "amplification",
+    });
+  });
+});

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -154,6 +154,27 @@ function computeTriggerWriteAmplification(
   return events.length / sourceOps.length;
 }
 
+export type LaneOverlayChipTone =
+  | "missing"
+  | "extra"
+  | "ordering"
+  | "lag"
+  | "schema"
+  | "ok"
+  | "amplification";
+
+export type LaneOverlayChip = { key: string; text: string; tone: LaneOverlayChipTone };
+
+export function formatWriteAmplificationChip(value: number): LaneOverlayChip | null {
+  if (!Number.isFinite(value)) return null;
+  if (value <= 0) return null;
+  return {
+    key: "write-amplification",
+    text: `${value.toFixed(1)}x write amplification`,
+    tone: "amplification",
+  } as const;
+}
+
 const METHOD_ORDER = ["polling", "trigger", "log"] as const;
 const MIN_LANES = 2;
 const STEP_MS = 100;
@@ -2681,11 +2702,16 @@ export function App() {
         const label = methodCopy[method].label;
         const totals = diff?.totals ?? { missing: 0, extra: 0, ordering: 0 };
         const maxLag = diff?.lag?.max ?? 0;
-        const chips: Array<{ key: string; text: string; tone: "missing" | "extra" | "ordering" | "lag" | "schema" | "ok" }> = [];
+        const chips: LaneOverlayChip[] = [];
         if (totals.missing > 0) chips.push({ key: "missing", text: `${totals.missing} missing`, tone: "missing" });
         if (totals.extra > 0) chips.push({ key: "extra", text: `${totals.extra} extra`, tone: "extra" });
         if (totals.ordering > 0) chips.push({ key: "ordering", text: `${totals.ordering} ordering`, tone: "ordering" });
         if (maxLag > 0) chips.push({ key: "lag", text: `${Math.round(maxLag)}ms lag`, tone: "lag" });
+        if (method === "trigger") {
+          const amplification = laneRuntimeSummaries.get(method)?.writeAmplification ?? 0;
+          const chip = formatWriteAmplificationChip(amplification);
+          if (chip) chips.push(chip);
+        }
         if (scenarioHasSchema) {
           const snapshot = laneDestinations.get(method);
           const schemaVersion = snapshot?.schemaVersion ?? 1;
@@ -2711,7 +2737,15 @@ export function App() {
           hasDetails,
         };
       }),
-    [activeMethods, laneDestinations, laneDiffs, methodCopy, schemaMaxVersion, scenarioHasSchema],
+    [
+      activeMethods,
+      laneDestinations,
+      laneDiffs,
+      laneRuntimeSummaries,
+      methodCopy,
+      schemaMaxVersion,
+      scenarioHasSchema,
+    ],
   );
 
   const userPinnedScenario = userSelectedScenarioRef.current;

--- a/web/styles/shell.css
+++ b/web/styles/shell.css
@@ -441,6 +441,16 @@
   color: #1d4ed8;
 }
 
+.sim-shell__overlay-chip--schema {
+  background: rgba(217, 70, 239, 0.2);
+  color: #a21caf;
+}
+
+.sim-shell__overlay-chip--amplification {
+  background: rgba(251, 146, 60, 0.25);
+  color: #c2410c;
+}
+
 .sim-shell__overlay-chip--ok {
   background: rgba(34, 197, 94, 0.2);
   color: #047857;


### PR DESCRIPTION
## Summary
- add a reusable formatter for trigger lane write-amplification chips and surface the metric in the lane overview
- style the new amplification and schema chips so the lane summary clearly calls out extra overhead
- cover the formatter with a small vitest to lock rounding and guard behavior

## Plan
1. introduce helper + types for lane overlay chips in `web/App.tsx`
2. push write-amplification chips into the overlay summary and add CSS styling
3. add vitest coverage for the formatter and run unit suite

## Changes
- `web/App.tsx`
- `web/styles/shell.css`
- `src/test/unit/writeAmplificationChip.test.ts`

## Verification
Commands:
```
npm run test:unit
```
Evidence:
- Vitest output (see run logs)

## Risks & Mitigations
- Highlight depends on trigger metrics -> falls back to existing summary when metric unavailable

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913bfea8b5c8323b47655e29f661eea)