### PR TITLE
Enable comparator schema walkthrough by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,6 +347,7 @@
         "ff_query_slider",
         "ff_crud_fix",
         "ff_event_log",
+        "ff_metrics",
         "ff_schema_demo",
         "ff_multitable"
       ]


### PR DESCRIPTION
## Summary
- The schema walkthrough buttons live inside the metrics dashboard, which was gated behind the `ff_metrics` flag and therefore missing when the comparator booted from `index.html`.
- Add the `ff_metrics` feature flag to the default Appwrite config so the runtime metrics card (and embedded schema walkthrough controls) render by default for local/preflight runs.

## Plan
1. Reproduce the failing Playwright test to confirm the schema walkthrough controls never render.
2. Inspect the feature-flag wiring in `index.html` and `web/App.tsx` to see why the metrics dashboard stays hidden.
3. Enable `ff_metrics` in the default config so the metrics dashboard — and thus the schema walkthrough buttons — always render locally.
4. Re-run the Playwright suite (or attempt to) to validate the fix.

## Changes
- `index.html` – include the `ff_metrics` flag in `window.APPWRITE_CFG.featureFlags` so the schema walkthrough controls mount.

## Verification
Commands:
```
npm run test:e2e
```
Evidence:
- Playwright could not download Chromium in this environment, so the suite failed early; see `npm run test:e2e` output for the missing `headless_shell` binary message.

## Risks & Mitigations
- Enabling metrics everywhere surfaces the metrics dashboard for all entry points, but the UI already shipped and is required for schema demo functionality.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a128391f88323b6bb14fbecaa27e3)