### PR TITLE
Relax transaction drift e2e timeouts

### DIFF
--- a/tests/e2e/transaction-drift.spec.mjs
+++ b/tests/e2e/transaction-drift.spec.mjs
@@ -47,12 +47,12 @@ suite("Transaction drift", () => {
     await page.waitForFunction(() => {
       const history = window.cdcComparatorDebug?.getLaneHistory("polling") ?? [];
       return history.includes(1) && history.includes(2);
-    }, undefined, { timeout: 5000 });
+    }, undefined, { timeout: 10000 });
 
     await page.waitForFunction(() => {
       const snapshot = window.cdcComparatorDebug?.getLaneSnapshot("polling");
       return Boolean(snapshot && snapshot.rows.length >= 3);
-    }, undefined, { timeout: 5000 });
+    }, undefined, { timeout: 10000 });
 
     const partialHistory = await page.evaluate(() => {
       return window.cdcComparatorDebug?.getLaneHistory("polling") ?? [];
@@ -70,7 +70,7 @@ suite("Transaction drift", () => {
     await page.waitForFunction(() => {
       const snapshot = window.cdcComparatorDebug?.getLaneSnapshot("polling");
       return Boolean(snapshot && snapshot.rows.length >= 3);
-    }, undefined, { timeout: 5000 });
+    }, undefined, { timeout: 10000 });
 
     const commitHistory = await page.evaluate(() => {
       return window.cdcComparatorDebug?.getLaneHistory("polling") ?? [];


### PR DESCRIPTION
## Summary
- Increase timeout allowances in the transaction drift Playwright spec so polling history and snapshot checks have more buffer on slower environments.
- Keep the existing throttling and apply-on-commit toggling flow intact while reducing flake risk in CI.
- No functional app changes beyond the test harness adjustments.

## Plan
1. Extend the waits around polling history and snapshot assertions in the transaction drift E2E test.
2. Run the targeted Playwright test to confirm stability (noting environment-installed browser availability).

## Changes
- tests/e2e/transaction-drift.spec.mjs

## Verification
Commands:
```
npm run test:e2e -- --grep "Transaction drift"
```
Evidence:
- Command currently fails in CI image when Playwright browsers are not installed (requires `npx playwright install`).

## Risks & Mitigations
- Longer timeouts increase test runtime slightly → limited to specific assertions and still bounded at 10s.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb197f1b083239c2a4dbab60c6659)