### PR TITLE
Align hero template grid beneath copy column

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -456,7 +456,11 @@ button.danger:hover {
 .hero {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "copy"
+    "templates"
+    "quickstart";
   gap: clamp(24px, 4vw, 40px);
   padding: clamp(28px, 5vw, 48px);
   border-radius: 24px;
@@ -467,12 +471,14 @@ button.danger:hover {
 }
 
 .hero-copy {
+  grid-area: copy;
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
 .hero-templates {
+  grid-area: templates;
   position: relative;
   z-index: 1;
   display: flex;
@@ -838,6 +844,7 @@ button.danger:hover {
 }
 
 .hero-quickstart {
+  grid-area: quickstart;
   background: rgba(18, 32, 59, 0.72);
   border: 1px solid rgba(91, 123, 181, 0.38);
   border-radius: 20px;
@@ -2813,6 +2820,15 @@ body.megadesk-mode .hero-ambient .orb {
   color: #cbd5f5;
   line-height: 1.4;
   font-size: 0.95rem;
+}
+
+@media (min-width: 1025px) {
+  .hero {
+    grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+    grid-template-areas:
+      "copy quickstart"
+      "templates quickstart";
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- Update the hero grid to use named areas so the scenario gallery sits directly beneath the intro copy on wide screens.
- Assign grid areas to the hero sections to create a consistent two-column layout beside the quickstart panel.
- Keep mobile responsiveness by preserving the stacked layout on narrower viewports.

## Plan
1. Adjust the hero grid definition to introduce named areas and a desktop-specific two-column arrangement.
2. Map the hero copy, templates, and quickstart sections to the new grid areas.
3. Verify the responsive breakpoints still stack content appropriately on smaller screens.

## Changes
- assets/styles.css

## Verification
Commands:
```
Not run (not requested).
```
Evidence:
- Not run (CSS-only change).

## Risks & Mitigations
- Potential layout regression on small screens → Maintain single-column grid in existing max-width breakpoints.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb15c18b8832382a1cb0093e75f59)