### PR TITLE
fix: reset consumer buffers on runner restart

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -3049,6 +3049,7 @@ export function App() {
       runner.reset(scenario.seed);
       setLaneEvents(emptyEventMap<CdcEvent>(activeMethods));
       setBusEvents(emptyEventMap<BusEvent>(activeMethods));
+      pendingTxnRef.current = {};
       laneSnapshotHistoryRef.current.forEach(series => series.splice(0));
       for (const method of activeMethods) {
         laneStorageRef.current[method] = new InMemoryTableStorage();
@@ -3059,6 +3060,7 @@ export function App() {
         updateLaneSnapshot(method, { lastOffset: -1 });
       }
       setClock(0);
+      consumerAllowanceRef.current = 0;
       schemaCommitRef.current = 0;
 
       if (!options?.keepLoop) {


### PR DESCRIPTION
## Summary
Updated the runner reset logic to clear consumer throttling allowance and pending transaction fragments, ensuring each restart begins from a clean state. This prevents carry-over transaction pieces from bypassing throttling and allows intermediate lane history to surface before full transactions are applied. Aligns reset behavior with expected queue draining semantics.

## Plan
1. Inspect current runner reset flow and consumer buffering refs.
2. Identify state that persists allowance or partial transactions across runs.
3. Add resets for consumer allowance and pending transaction buffers.
4. Verify reset flow still restores lane storage and metrics.
5. Prepare PR summary and notes.

## Changes
- web/App.tsx

## Verification
Commands:
```
# not run (not requested)
```
Evidence:
- N/A

## Risks & Mitigations
- Reset logic might omit other hidden buffers → manual smoke test resets/playback after merge.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcfbcce708323a8f9eb05dd13dc20)