### PR TITLE
Add CDC demo playbook for guided change feed walkthroughs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Latest assessment:
 - 📊 [Implementation Review Summary](docs/REVIEW_SUMMARY.md) – Quick overview of strengths, gaps, and risks
 - 📋 [Implementation Status Report](docs/IMPLEMENTATION_STATUS.md) – Deep dive across architecture, tests, and feature flags
 - 🎯 [Action Plan](docs/ACTION_PLAN.md) – Prioritized follow-ups to reach world-class readiness
+- 🎬 [CDC Demo Playbook](docs/cdc-demo-playbook.md) – Ready-to-run scripts for showcasing change feed behaviors
 
 ## Contributing
 

--- a/docs/cdc-demo-playbook.md
+++ b/docs/cdc-demo-playbook.md
@@ -1,0 +1,69 @@
+# CDC Demo Playbook
+
+Use these scripts to deliver crisp, repeatable walkthroughs of the playground for data engineers and architects. Each flow pairs a curated scenario with the comparator controls so you can highlight why different capture methods behave the way they do.
+
+## Prerequisites
+
+- Run `npm install && npm run build` to generate `assets/generated/` bundles.
+- Open `index.html` from the project root (double-click or `open index.html`).
+- Confirm the comparator is visible (`Preparing simulator preview…` goes away once bundles are built).
+- Reset the workspace via **Clear workspace** if a previous session left residual state.
+
+## Quick reference
+
+| Demo | Best for | Controls to tweak |
+| ---- | -------- | ----------------- |
+| CRUD basics | Showing delete visibility and polling lag | Polling interval + soft-delete visibility |
+| Schema evolution | Column backfills and schema drift | Add column, backfill toggle, trigger vs. log comparison |
+| Orders + items transactions | Multi-table atomicity and apply-on-commit | Apply-on-commit toggle + lag overlays |
+
+## Demo 1 – CRUD basics and delete capture
+
+1. Load the **CRUD Basic** scenario from the gallery or comparator quick-pick.
+2. Enable the **Polling** and **Log** methods; keep **Trigger** off to focus the contrast.
+3. Set **Polling interval** to 350–500ms to exaggerate lag.
+4. Start the run and expand the **Event Log**.
+5. Highlight that deletes may be invisible in polling until the next sweep, while the log method emits the delete instantly.
+6. Toggle **Soft deletes** on and off to show how tombstones appear vs. disappear downstream.
+
+**Talking points**
+- Why polling needs either tombstones or periodic full refreshes to avoid ghost rows.
+- How log-based capture handles deletes even when the source row is already gone.
+- How downstream consumers can mis-order events if the poll cadence is too wide.
+
+## Demo 2 – Schema evolution with backfill expectations
+
+1. Load **Schema Evolution**.
+2. Run once with **Trigger** and **Log** both enabled to establish a baseline.
+3. In the **Schema** panel, add a column (e.g., `loyalty_notes` as `string`) and choose **Backfill existing rows**.
+4. Rerun and pause mid-stream to observe:
+   - **Log** emits the schema change immediately, followed by backfilled values.
+   - **Trigger** may lag until the next trigger cycle but preserves column order and defaults.
+5. Flip **Backfill existing rows** off and rerun to show how nulls appear downstream and how consumers should guard for missing columns.
+6. Use the **Lane diff overlay** to pinpoint any missing updates caused by backfill choices.
+
+**Talking points**
+- Schema propagation order: DDL first, then DML, and why some sinks need schema compatibility mode.
+- Backfill trade-offs: immediate correctness vs. bursty load on the source.
+- Why feature flags (`ff_trigger_mode`, `ff_walkthrough`) stay enabled for this flow.
+
+## Demo 3 – Orders + items with apply-on-commit
+
+1. Load **Orders + Items Transactions**.
+2. Enable **Trigger** and **Log**; keep **Polling** optional to show worst-case lag.
+3. Turn **Apply on commit** **on** so downstream apply waits for all operations in a transaction.
+4. Run and open the **Lane checks summary** to confirm both methods stay aligned with no missing rows.
+5. Turn **Apply on commit** **off** and rerun to show transient gaps where orders appear without items (or vice versa).
+6. Use **Load in workspace** to push the scenario back to the main playground and experiment with additional updates.
+
+**Talking points**
+- Multi-entity writes and why ordering guarantees matter for referential integrity.
+- How log vs. trigger capture handle transaction grouping and why apply-on-commit is safer for downstream joins.
+- Interpreting lag overlays to spot the precise point where ordering breaks.
+
+## Tips for live sessions
+
+- Keep the **Metrics dashboard** open to call out backlog and lag percentiles per method.
+- Use the **NDJSON export** from the Event Log when attendees want to inspect raw change events.
+- If Playwright or harness tests recently failed, rerun `npm run check:bundles` to confirm local assets match sources before presenting.
+- Share the **Scenario matrix** from the README when handing off self-serve exploration.


### PR DESCRIPTION
## Summary
- add a CDC demo playbook with three ready-to-run flows that highlight delete capture, schema evolution, and transactional ordering
- link the new playbook from the README documentation section for quick discovery

## Plan
1. Review existing docs to align tone and terminology
2. Draft guided demo scripts covering core CDC change feed behaviors
3. Add prerequisites and quick-reference table for presenters
4. Cross-link the playbook from the main README for discoverability
5. Run available lint/check scripts touching scenarios or docs

## Changes
- docs/cdc-demo-playbook.md
- README.md

## Verification
Commands:
```
npm run lint:scenarios
```
Evidence:
- lint:scenarios output

## Risks & Mitigations
- Docs could drift from UI labels → kept steps aligned with existing scenario names and controls; easy to update if labels change

## Follow-ups
- Add screenshots or short Looms that pair with the demo scripts once UI stabilizes


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd11734b88323a8e16c264cd82823)