### PR TITLE
Fix onboarding scroll lock after loading template

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1217,9 +1217,9 @@ function deriveOpsFromEvents(events) {
 
 function hideOnboarding(markSeen = false) {
   ensureOnboardingElements();
+  document.body.classList.remove("is-onboarding");
   if (!els.onboardingOverlay) return;
   els.onboardingOverlay.hidden = true;
-  document.body.classList.remove("is-onboarding");
   if (markSeen) storage.set(STORAGE_KEYS.onboarding, "seen");
 }
 


### PR DESCRIPTION
## Summary
- Prevent the onboarding scroll lock from persisting after loading the Orders template.
- Always clear the body scroll state even when the onboarding overlay reference is missing.
- Verified the behavior with the existing unit test suite.

## Plan
1. Inspect onboarding show/hide behavior when loading templates.
2. Adjust scroll lock teardown to always clear the body class.
3. Run unit suite to guard regressions.

## Changes
- assets/app.js

## Verification
Commands:
```
npm run test:unit
```
Evidence:
- `npm run test:unit` console output

## Risks & Mitigations
- Potential unforeseen onboarding interactions → Covered by existing unit tests; manual check recommended in review.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd67289a8832397a52012374ff659)