### PR TITLE
Sync comparator throttle refs for transaction drift coverage

### DIFF
--- a/web/App.tsx
+++ b/web/App.tsx
@@ -2279,24 +2279,31 @@ export function App() {
     setConsumerRateEnabled(prev => {
       const next = !prev;
       track("comparator.consumer.rate_toggle", { scenario: scenario.name, enabled: next });
+      consumerThrottleRef.current = next ? consumerRateLimit : null;
+      if (!next) {
+        consumerAllowanceRef.current = 0;
+      }
       return next;
     });
     if (consumerRateEnabled) {
       track("comparator.consumer.rate_reset", { scenario: scenario.name });
     }
-  }, [consumerRateEnabled, scenario.name]);
+  }, [consumerRateEnabled, consumerRateLimit, scenario.name]);
 
   const handleConsumerRateChange = useCallback(
     (value: number) => {
       const clamped = sanitizeConsumerRate(value, consumerRateLimit);
       if (clamped === consumerRateLimit) return;
       setConsumerRateLimit(clamped);
+      if (consumerRateEnabled) {
+        consumerThrottleRef.current = clamped;
+      }
       track("comparator.consumer.rate_adjust", {
         scenario: scenario.name,
         rate: clamped,
       });
     },
-    [consumerRateLimit, scenario.name],
+    [consumerRateEnabled, consumerRateLimit, scenario.name],
   );
 
   const handleToggleGenerator = useCallback(() => {


### PR DESCRIPTION
## Summary
- Update the comparator's consumer rate toggle to synchronously update internal throttle refs when enabling/disabling throttling.
- Reset allowance immediately when removing the throttle to avoid stale capacity leaking into subsequent runs.
- Apply rate changes directly to the throttle ref when the slider moves so throttling is effective from the next tick.

## Plan
1. Update the consumer rate toggle handler to keep the throttle ref and allowance in sync with the UI state.
2. Apply slider changes directly to the throttle ref when throttling is enabled.
3. Smoke the transaction-drift Playwright test (blocked locally by missing Playwright browsers).

## Changes
- web/App.tsx

## Verification
Commands:
```
npm run test:e2e -- --grep "Transaction drift" --max-failures=1
```
Evidence:
- Blocked locally: Playwright browsers are not installed in the runner environment.

## Risks & Mitigations
- Throttle sync changes could subtly alter consumer pacing: kept logic additive and preserved existing defaults while only updating refs eagerly.

## Follow-ups
- Re-run the full Playwright suite once browsers are available to confirm the transaction drift test passes end-to-end.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bddc826788323977ff41f1b4c5bae)