### PR TITLE
Stack hero templates under heading at large widths

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2883,14 +2883,6 @@ body.megadesk-mode .hero-ambient .orb {
   font-size: 0.95rem;
 }
 
-@media (min-width: 1025px) {
-  .hero {
-    grid-template-columns: minmax(320px, 1fr) minmax(420px, 1fr);
-    grid-template-areas: "copy templates";
-  }
-}
-
-
 @media (max-width: 1024px) {
   .hero {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- Keep the hero pathways and scenario gallery stacked beneath the main heading even on wide screens for consistent layout.
- Removes the large-screen two-column grid override to mirror the small-screen presentation users expect.
- Verified the updated layout visually at desktop resolution.

## Plan
1. Adjust hero grid rules to maintain a single-column stack across breakpoints.
2. Serve the static page locally and confirm the hero content order matches small-screen behavior.

## Changes
- Remove the min-width breakpoint that previously split the hero into two columns (`assets/styles.css`).

## Verification
Commands:
```
# Manual verification via local static server
python -m http.server 8000
```
Evidence:
- Updated hero layout at 1920px width ![stacked hero screenshot](browser:/invocations/ysvhuevz/artifacts/artifacts/hero-stacked.png)

## Risks & Mitigations
- None identified; change is limited to layout stacking. Visual check confirms expected order.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca4ed26448323bb149f730ad61425)