### PR TITLE
Remove guided walkthrough CTA buttons

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -642,12 +642,10 @@ const els = {
   autofillRow: document.getElementById("btnAutofillRow"),
   templateGallery: document.getElementById("templateGallery"),
   onboardingOverlay: document.getElementById("onboardingOverlay"),
-  onboardingButton: document.getElementById("btnOnboarding"),
   onboardingClose: document.getElementById("onboardingClose"),
   onboardingDismiss: document.getElementById("onboardingDismiss"),
   onboardingStart: document.getElementById("onboardingStart"),
   onboardingEasterEgg: document.getElementById("onboardingEasterEgg"),
-  guidedTourButton: document.getElementById("btnGuidedTour"),
   methodGuidance: document.getElementById("methodGuidance"),
   saveRemote: document.getElementById("btnSaveRemote"),
   shareLink: document.getElementById("btnShareLink"),
@@ -675,9 +673,6 @@ function ensureOnboardingElements() {
   if (!els.onboardingOverlay) {
     els.onboardingOverlay = document.getElementById("onboardingOverlay");
   }
-  if (!els.onboardingButton) {
-    els.onboardingButton = document.getElementById("btnOnboarding");
-  }
   if (!els.onboardingClose) {
     els.onboardingClose = document.getElementById("onboardingClose");
   }
@@ -693,7 +688,6 @@ function ensureOnboardingElements() {
 }
 
 if (typeof document !== "undefined") {
-  document.getElementById("btnGuidedTour")?.addEventListener("click", () => startGuidedTour());
   document.getElementById("btnReset")?.addEventListener("click", () => {
     storage.remove(STORAGE_KEYS.state);
     storage.remove(STORAGE_KEYS.lastTemplate);
@@ -4578,9 +4572,6 @@ function bindUiHandlers() {
     document.addEventListener("keydown", handleMegadeskShortcut);
   }
 
-  if (els.onboardingButton) {
-    els.onboardingButton.onclick = () => showOnboarding();
-  }
   if (els.onboardingClose) {
     els.onboardingClose.onclick = () => hideOnboarding(true);
   }

--- a/index.html
+++ b/index.html
@@ -63,14 +63,6 @@
                 Start with the guided walkthrough to experience the full flow, or
                 jump straight into curated CDC blueprints.
               </p>
-              <div class="hero-pathways-actions">
-                <button id="btnGuidedTour" type="button" class="btn-primary">
-                  Start guided walkthrough
-                </button>
-                <button type="button" id="btnOnboarding" class="btn-ghost">
-                  How the playground works
-                </button>
-              </div>
               <p class="hero-pathways-tip">
                 Want presets instead? Pick any scenario below to load schema,
                 rows, and starting operations instantly.


### PR DESCRIPTION
## Summary
- Remove the hero CTA buttons for the guided walkthrough and onboarding overlay from the landing layout.
- Clean up DOM lookups and event bindings that referenced the removed controls in the static playground script.
- Verified the hero renders without the CTAs and captured an updated screenshot.

## Plan
1. Locate the hero CTA markup and supporting JavaScript hooks.
2. Remove the guided walkthrough/onboarding buttons from the hero section.
3. Delete now-unused element lookups and click handlers tied to those controls.
4. Load the static site to confirm the hero renders correctly without the buttons.
5. Capture a screenshot of the updated hero area.

## Changes
- index.html
- assets/app.js

## Verification
Commands:
```
None (UI-only change)
```
Evidence:
- Updated hero without CTA buttons: browser:/invocations/nyyvvxoc/artifacts/artifacts/hero-no-walkthrough-buttons.png

## Risks & Mitigations
- Reduced discoverability of the guided walkthrough/onboarding entry point → Onboarding overlay still appears automatically for first-time/default scenarios.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb3d2b0f88323953307f2f419f0b2)