### PR TITLE
Restore guided walkthrough CTAs

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -717,6 +717,9 @@ function ensureOnboardingElements() {
 if (typeof document !== "undefined") {
   ensureHeroCtas();
   document.getElementById("btnGuidedTour")?.addEventListener("click", () => startGuidedTour());
+  document.getElementById("btnOnboarding")?.addEventListener("click", () => {
+    showOnboarding();
+  });
   document.getElementById("btnReset")?.addEventListener("click", () => {
     storage.remove(STORAGE_KEYS.state);
     storage.remove(STORAGE_KEYS.lastTemplate);

--- a/index.html
+++ b/index.html
@@ -63,6 +63,14 @@
                 Start with the guided walkthrough to experience the full flow, or
                 jump straight into curated CDC blueprints.
               </p>
+              <div class="hero-pathways-actions">
+                <button type="button" class="btn-primary" id="btnGuidedTour">
+                  Start guided walkthrough
+                </button>
+                <button type="button" class="btn-ghost" id="btnOnboarding">
+                  How the playground works
+                </button>
+              </div>
               <p class="hero-pathways-tip">
                 Want presets instead? Pick any scenario below to load schema,
                 rows, and starting operations instantly.


### PR DESCRIPTION
## Summary
- Reintroduce guided walkthrough and onboarding call-to-action buttons in the hero pathways block so users can launch tours directly from the landing experience.
- Hook the onboarding CTA to show the onboarding overlay alongside the existing guided tour handler.
- Preserve the dynamic CTA creation fallback for environments that rely on script-only insertion.

## Plan
1. Review the guided walkthrough markup and CTA handling.
2. Reinstate the CTA container and buttons in the guided walkthrough copy block.
3. Wire the onboarding CTA to trigger the onboarding overlay with the existing handler.
4. Ensure styles align with the existing hero pathways layout and accessibility hooks.
5. Document the change in this PR for review.

## Changes
- index.html
- assets/app.js

## Verification
Commands:
```
# not run (UI-only change)
```
Evidence:
- not run (UI-only change)

## Risks & Mitigations
- Potential styling regressions in the hero CTA row → Reuse existing `hero-pathways-actions` styles; reviewers can spot-check in browser.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cc88ac77883239fff03b2cde32b76)