### PR TITLE
Add CDC method comparator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Latest assessment:
 - 🎯 [Action Plan](docs/ACTION_PLAN.md) – Prioritized follow-ups to reach world-class readiness
 - 🎬 [CDC Demo Playbook](docs/cdc-demo-playbook.md) – Ready-to-run scripts for showcasing change feed behaviors
 - 🧪 [CDC Lab Recipes](docs/cdc-lab-recipes.md) – Guided labs that highlight latency, ordering, schema change, and delete semantics
+- 🧭 [CDC Method Comparator Guide](docs/comparator-guide.md) – How to launch, navigate, and demo the React comparator shell
 
 ## Contributing
 

--- a/docs/cdc-demo-playbook.md
+++ b/docs/cdc-demo-playbook.md
@@ -2,6 +2,8 @@
 
 Use these scripts to deliver crisp, repeatable walkthroughs of the playground for data engineers and architects. Each flow pairs a curated scenario with the comparator controls so you can highlight why different capture methods behave the way they do.
 
+For a fast orientation to the comparator UI before presenting these flows, skim the [CDC Method Comparator Guide](./comparator-guide.md).
+
 ## Prerequisites
 
 - Run `npm install && npm run build` to generate `assets/generated/` bundles.

--- a/docs/comparator-guide.md
+++ b/docs/comparator-guide.md
@@ -1,0 +1,50 @@
+# CDC Method Comparator Guide
+
+The CDC Method Comparator (`#simShellRoot`) is the React shell that streams the Polling, Trigger, and Log capture engines side by side so you can see ordering, lag, and delete semantics in one place. Use this guide to launch it locally, pick the right knobs, and run demos with data engineers or architects evaluating change feed patterns.
+
+## Prerequisites
+- Node 18+ and npm installed locally.
+- Bundles generated at least once via `npm run build` (creates `assets/generated/ui-shell.js` and `assets/generated/ui-shell.css`).
+- Optional but recommended: run `npm run build:sim` to rebuild simulator engines if you touched any `sim/` sources.
+
+## Launching the comparator
+1. Install dependencies: `npm install`.
+2. Build the bundles (needed for the React shell): `npm run build`.
+3. Open `index.html` in a browser (double-click or `open index.html`).
+4. Scroll to the **CDC Method Comparator** section. If you see "Preparing simulator preview…" refresh after the build finishes.
+
+### Development loop
+- Use `npm run dev:all` to run sim + web Vite dev servers with live reload. The comparator mounts at `/web` while `index.html` still works for bundle snapshots.
+- The comparator persists preferences in localStorage. Use the **Reset comparator** button in the preferences panel to clear state between demos.
+
+## Interface tour
+- **Scenario picker**: Choose curated scenarios from `assets/shared-scenarios.js` or load the live workspace feed. Scenario cards surface tags (orders, payments, lag) and highlights to help select the right story.
+- **Method toggles**: Enable Polling, Trigger, or Log lanes individually to isolate a capture approach. Polling includes a soft-delete visibility toggle; Trigger exposes trigger overhead; Log exposes binlog/WAL fetch cadence.
+- **Event log overlay**: Click **Inspect** on any lane or the lane diff overlays to open the unified event log. Filter by operation type, table, or method to trace divergence.
+- **Lane diffs**: Overlays highlight missing/extra/out-of-order operations per method. The summary chips explain where lag or ordering drift appears and tie back to exact events.
+- **Metrics dashboard**: Shows produced/consumed counts, backlog, and lag percentiles. Use it to quantify changes when tweaking polling intervals or trigger overhead.
+- **Apply-on-commit**: When enabled, downstream apply waits until a transaction’s full batch is present. Use this in multi-table demos to contrast atomic vs. streaming apply.
+- **Exports/imports**: Export preferences and the last insight snapshot to a JSON file; import it later to replay the same comparator state.
+
+## Demo recipes
+- **Lag and ordering primer (CRUD Basic)**
+  - Enable all three methods; leave apply-on-commit off.
+  - Slowly step through events and open lane diffs to show how Polling lags behind Trigger/Log and can reorder updates around deletes.
+- **Trigger overhead vs. latency (Real-time Payments)**
+  - Toggle Trigger on/off while watching the metrics dashboard. Increase **Trigger cadence** to show how overhead impacts tail latency but still preserves ordering.
+- **Delete semantics (Retention & Erasure)**
+  - Turn on Polling with soft deletes visible and Log without apply-on-commit. Show how Polling surfaces deletes as tombstones only when the record is observed, while Log captures the delete immediately.
+- **Schema evolution (Schema Evolution)**
+  - Trigger a column add in the scenario controls, then inspect events. Log propagates column changes immediately; Polling sees them after the next snapshot or diff cycle.
+- **Snapshot re-seed (Snapshot Replay)**
+  - Reset offsets for Polling to simulate a snapshot resume. Use lane diffs to illustrate how dedupe and apply-on-commit avoid double-apply after the snapshot completes.
+
+## Troubleshooting
+- Comparator stuck on "Enable the comparator_v2 feature flag": run `npm run build` to regenerate bundles so the shell code is available.
+- Event log looks stale after editing scenarios: rerun `npm run build:sim` to rebuild simulator engines, then refresh `index.html`.
+- Playwright or browser launch errors when running tests: install browsers locally with `npx playwright install --with-deps` (documented in `docs/development.md`).
+
+## Deep dives
+- [CDC Demo Playbook](./cdc-demo-playbook.md) – narrative scripts to deliver during workshops.
+- [CDC Lab Recipes](./cdc-lab-recipes.md) – hands-on labs for latency, ordering, schema, and delete semantics.
+- [Performance Budgets](./performance-budgets.md) – baseline metrics and guardrails for the comparator shell.


### PR DESCRIPTION
## Summary
- Add a focused CDC Method Comparator Guide to help data engineers launch and demo the React comparator shell consistently.
- Link the new guide from README and the CDC Demo Playbook so presenters can find it quickly.
- Capture troubleshooting notes and demo recipes that emphasize lag, ordering, deletes, schema changes, and snapshot resumes.

## Plan
1. Review existing comparator documentation and usage guidance.
2. Draft a concise comparator guide covering launch steps, controls, and demo scripts.
3. Link the guide from README and demo playbook for discoverability.
4. Run documentation-adjacent checks to ensure nothing else regressed.
5. Prepare PR summary and follow-ups.

## Changes
- Added `docs/comparator-guide.md` with prerequisites, interface tour, demo recipes, and troubleshooting tips.
- Updated `README.md` to reference the comparator guide alongside other docs.
- Updated `docs/cdc-demo-playbook.md` to point presenters to the new comparator orientation guide.

## Verification
Commands:
```
npm run lint:scenarios
```
Evidence:
- `npm run lint:scenarios` (pass)

## Risks & Mitigations
- Guidance lacks screenshots or clips for the UI → follow-up to add visuals if helpful.

## Follow-ups
- Add screenshots or short clips to the comparator guide once the UI stabilizes.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d35a1a7d88323be7ec6fa41f46ba1)