### PR TITLE
Refresh template gallery stats styling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1206,19 +1206,56 @@ function renderTemplateGallery() {
     const ops = Array.isArray(template.ops) ? template.ops.length : 0;
 
     const stats = [
-      { label: "Seed rows", value: rows },
-      { label: "Ops queued", value: ops },
+      {
+        label: "Seed rows",
+        value: rows,
+        className: "template-stat--rows",
+        iconPath: "M6 8.5h12m-12 4h12M6 12.5v3.75A1.25 1.25 0 0 0 7.25 17.5h9.5A1.25 1.25 0 0 0 18 16.25V12.5m0-4.75V7.75A1.25 1.25 0 0 0 16.75 6.5h-9.5A1.25 1.25 0 0 0 6 7.75V7.9",
+      },
+      {
+        label: "Ops queued",
+        value: ops,
+        className: "template-stat--ops",
+        iconPath: "M6.75 8.75v-2m0 0h-2m2 0 6.5 6.5m4-4v2m0 0h2m-2 0-2.75-2.75M7 18h10.25M7 15.5h6.5",
+      },
     ];
+
+    const buildStatIcon = pathD => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("viewBox", "0 0 24 24");
+      svg.setAttribute("aria-hidden", "true");
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", pathD);
+      path.setAttribute("fill", "none");
+      path.setAttribute("stroke", "currentColor");
+      path.setAttribute("stroke-width", "1.5");
+      path.setAttribute("stroke-linecap", "round");
+      path.setAttribute("stroke-linejoin", "round");
+      svg.appendChild(path);
+      return svg;
+    };
 
     stats.forEach(stat => {
       const statEl = document.createElement("span");
-      statEl.className = "template-stat";
+      statEl.className = `template-stat ${stat.className}`;
+
+      const iconWrap = document.createElement("span");
+      iconWrap.className = "template-stat__icon";
+      iconWrap.appendChild(buildStatIcon(stat.iconPath));
+
+      const textWrap = document.createElement("span");
+      textWrap.className = "template-stat__text";
       const valueEl = document.createElement("strong");
       valueEl.textContent = String(stat.value);
+      valueEl.className = "template-stat__value";
       const labelEl = document.createElement("small");
       labelEl.textContent = stat.label;
-      statEl.appendChild(valueEl);
-      statEl.appendChild(labelEl);
+      labelEl.className = "template-stat__label";
+      textWrap.appendChild(valueEl);
+      textWrap.appendChild(labelEl);
+
+      statEl.appendChild(iconWrap);
+      statEl.appendChild(textWrap);
       metaRow.appendChild(statEl);
     });
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -912,34 +912,72 @@ body[data-theme="light"] .template-card__kicker {
 .template-card__meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
   align-items: center;
-  margin-top: 2px;
+  margin-top: 4px;
 }
 
 .template-stat {
+  --stat-from: rgba(59, 130, 246, 0.1);
+  --stat-to: rgba(56, 189, 248, 0.08);
+  --stat-border: rgba(82, 114, 169, 0.45);
+  --stat-icon-bg: rgba(255, 255, 255, 0.08);
+  --stat-icon-color: #dce8ff;
   display: inline-flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 2px;
-  padding: 8px 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(82, 114, 169, 0.4);
-  background: rgba(24, 36, 64, 0.7);
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--stat-border);
+  background: linear-gradient(140deg, var(--stat-from), var(--stat-to));
   color: #e2e8f0;
-  min-width: 96px;
+  min-width: 120px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
-.template-stat strong {
-  font-size: 15px;
+.template-stat__icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--stat-icon-bg);
+  color: var(--stat-icon-color);
+  border: 1px solid var(--stat-border);
+}
+
+.template-stat__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.template-stat__value {
+  font-size: 16px;
   line-height: 1.1;
 }
 
-.template-stat small {
+.template-stat__label {
   font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: rgba(226, 232, 240, 0.68);
+}
+
+.template-stat--rows {
+  --stat-from: rgba(16, 185, 129, 0.2);
+  --stat-to: rgba(45, 212, 191, 0.12);
+  --stat-border: rgba(16, 185, 129, 0.5);
+  --stat-icon-bg: rgba(16, 185, 129, 0.22);
+  --stat-icon-color: #eafff7;
+}
+
+.template-stat--ops {
+  --stat-from: rgba(249, 115, 22, 0.22);
+  --stat-to: rgba(251, 146, 60, 0.12);
+  --stat-border: rgba(251, 146, 60, 0.55);
+  --stat-icon-bg: rgba(251, 146, 60, 0.22);
+  --stat-icon-color: #fff7ec;
 }
 
 .template-card__metrics {
@@ -1127,6 +1165,35 @@ body[data-theme="light"] .template-card__status {
   background: rgba(219, 234, 254, 0.6);
   border-color: rgba(96, 165, 250, 0.5);
   color: #1e40af;
+}
+
+body[data-theme="light"] .template-stat {
+  color: #0f172a;
+  --stat-from: rgba(59, 130, 246, 0.14);
+  --stat-to: rgba(56, 189, 248, 0.1);
+  --stat-border: rgba(148, 163, 184, 0.7);
+  --stat-icon-bg: rgba(255, 255, 255, 0.75);
+  --stat-icon-color: #0f172a;
+}
+
+body[data-theme="light"] .template-stat__label {
+  color: rgba(15, 23, 42, 0.68);
+}
+
+body[data-theme="light"] .template-stat--rows {
+  --stat-from: rgba(16, 185, 129, 0.16);
+  --stat-to: rgba(52, 211, 153, 0.12);
+  --stat-border: rgba(16, 185, 129, 0.55);
+  --stat-icon-bg: rgba(16, 185, 129, 0.2);
+  --stat-icon-color: #0f172a;
+}
+
+body[data-theme="light"] .template-stat--ops {
+  --stat-from: rgba(249, 115, 22, 0.2);
+  --stat-to: rgba(251, 146, 60, 0.14);
+  --stat-border: rgba(249, 115, 22, 0.55);
+  --stat-icon-bg: rgba(251, 146, 60, 0.24);
+  --stat-icon-color: #0f172a;
 }
 
 body[data-theme="light"] .template-metric {


### PR DESCRIPTION
## Summary
- Revamp the template gallery stat badges with color-coded icons and clearer layout to make rows and queued ops easier to scan.
- Introduce gradient backgrounds and spacing tweaks for the meta row, plus light-theme overrides to keep contrast in both themes.
- Preserve existing template card structure while adding reusable icon rendering for the stat chips.

## Plan
1. Locate the template gallery stat rendering logic in the static playground shell.
2. Add richer metadata (icons/classes) for the rows and ops stats and build an SVG helper.
3. Update the DOM construction to include icon + text wrappers for each stat.
4. Redesign the stat badge styles with gradients, spacing tweaks, and themed variants.
5. Add light theme overrides, run unit tests, and capture a visual snapshot.

## Changes
- assets/app.js
- assets/styles.css

## Verification
Commands:
```
npm run test:unit
```
Evidence:
- ![Updated template stats](browser:/invocations/rrwchmvr/artifacts/artifacts/template-stats.png)

## Risks & Mitigations
- Color contrast regressions → Added light-theme overrides and kept high-contrast text colors.

## Follow-ups
- Consider reflecting live queue depth in the ops badge when pause/resume is enabled.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d3e8810ac83238ec95bbf3ee7bf12)