### PR TITLE
Draft: add CDC method cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Latest assessment:
 - 🎯 [Action Plan](docs/ACTION_PLAN.md) – Prioritized follow-ups to reach world-class readiness
 - 🎬 [CDC Demo Playbook](docs/cdc-demo-playbook.md) – Ready-to-run scripts for showcasing change feed behaviors
 - 🧪 [CDC Lab Recipes](docs/cdc-lab-recipes.md) – Guided labs that highlight latency, ordering, schema change, and delete semantics
+- 🧠 [CDC Method Cheat Sheet](docs/cdc-method-cheatsheet.md) – Quick selection guide for Polling, Triggers, Log, and Outbox
 - ✅ [Change Feed Evaluation Checklist](docs/change-feed-evaluation-checklist.md) – Quick scoring script for comparing Polling, Trigger, and Log capture
 - 🧭 [CDC Method Comparator Guide](docs/comparator-guide.md) – How to launch, navigate, and demo the React comparator shell
 - ⚙️ [Configuration Guide](docs/configuration-guide.md) – Run-mode matrix, feature flag sources, and Appwrite setup tips

--- a/docs/cdc-method-cheatsheet.md
+++ b/docs/cdc-method-cheatsheet.md
@@ -1,0 +1,82 @@
+# CDC Method Cheat Sheet
+
+Use this page as a quick reference when deciding which capture pattern to demonstrate in the playground or comparator. Each method includes a mental model, strengths, gotchas, and demo tips tailored for data engineers and architects.
+
+## Polling
+- **Ideal for:** Legacy databases or read-only replicas without log access.
+- **How it works:** Periodically query the source table with a high-water mark (timestamp or incrementing key) to pull new or updated rows.
+- **Strengths:**
+  - Low operational risk; no database configuration changes required.
+  - Easy to prototype in the playground; set `poll_interval_ms` to visualize lag.
+  - Works even when binary logs are disabled or unavailable.
+- **Gotchas:**
+  - Higher latency under bursty writes; gaps between polls can hide rapid updates.
+  - Deletes are hard to spot unless soft-delete flags exist or tombstones are emitted.
+  - Backfills can overload the source if intervals are too aggressive.
+- **Demo tips:**
+  - Start from the **CRUD Basic** or **Omnichannel Orders** scenarios, set a slow poll interval, and issue back-to-back updates to highlight lag and missing deletes.
+  - Toggle soft-delete visibility to show how downstream systems react when deletes are invisible to polling.
+
+## Triggers (Change Tables)
+- **Ideal for:** Teams who can add lightweight triggers or change tables without relying on WAL/binlog access.
+- **How it works:** Database triggers capture row-level operations into an audit/change table; a downstream process drains that table to emit CDC events.
+- **Strengths:**
+  - Precise row-level change capture with delete visibility baked in.
+  - Can include rich business context (actor IDs, reason codes) in the change table schema.
+  - Works even when logs rotate quickly or are inaccessible.
+- **Gotchas:**
+  - Adds write-path overhead; poorly written triggers can degrade OLTP performance.
+  - Requires schema management for the change table and trigger code during upgrades.
+  - Ordering across tables is not guaranteed unless you include transaction metadata.
+- **Demo tips:**
+  - Use the **Real-time Payments** scenario and enable the trigger method in the comparator to show minimal lag but clear write overhead.
+  - Highlight the `apply_on_commit` toggle to demonstrate how triggers capture multi-row transactions and how downstream apply can stay atomic.
+
+## Log-based (WAL/Binlog)
+- **Ideal for:** Production-grade pipelines where low latency and strong ordering matter.
+- **How it works:** Tail the database write-ahead log or binlog to stream inserts, updates, and deletes with transaction boundaries.
+- **Strengths:**
+  - Lowest capture latency with commit-ordering preserved.
+  - No write-path overhead on the source tables.
+  - Captures schema changes (add/drop columns) when configured correctly.
+- **Gotchas:**
+  - Requires log access and retention tuning; log rotation can break readers.
+  - Schema drift needs careful handling to avoid deserialization failures.
+  - Initial snapshots must be coordinated with log positions to avoid duplicate or missing events.
+- **Demo tips:**
+  - Pair the **Schema Evolution** or **Snapshot ➜ Stream Handoff** scenarios with log capture to show column additions flowing through immediately.
+  - Stress-test ordering by toggling the **Burst Updates** scenario and comparing lag overlays between log and polling.
+
+## Outbox
+- **Ideal for:** Event-driven architectures where business events must be curated and idempotent.
+- **How it works:** Application writes domain events into an outbox table within the same transaction as the source table mutation; a relay publishes those events to downstream transports.
+- **Strengths:**
+  - Full control over event shape, routing keys, and idempotency tokens.
+  - Transactional with source writes, preventing double-publish or lost events.
+  - Decouples change capture from internal schema details.
+- **Gotchas:**
+  - Requires application changes and careful retry/deduplication logic in the relay.
+  - Outbox growth must be managed (TTL or vacuum); otherwise drains fall behind.
+  - Consistency between outbox and source tables depends on reading both within the same transaction.
+- **Demo tips:**
+  - Load the **Outbox Relay** scenario and enable log + outbox side by side in the comparator to illustrate business-event ordering vs. raw row changes.
+  - Show how the **Snapshot ➜ Stream Handoff** scenario behaves when the outbox feeds a downstream service that expects strict idempotency keys.
+
+## Quick Selection Guide
+Use this decision helper during workshops or live demos:
+
+- **Need lowest lag and strict ordering?** Choose **Log-based** and demonstrate transaction boundaries with `apply_on_commit` enabled.
+- **No log access but can add database code?** Choose **Triggers** to keep delete visibility intact and attach business context.
+- **Running on a replica or constrained environment?** Start with **Polling** and tune intervals; call out delete limitations.
+- **Emitting business events to multiple sinks?** Use **Outbox** to craft domain events and dedupe downstream with idempotency keys.
+- **Unsure?** Start with **Polling** for safety, then graduate to **Log-based** once access is available.
+
+## How to Use in the Playground
+1. Open `index.html` and click **Start guided walkthrough** to seed a schema and rows.
+2. Launch the **CDC Method Comparator** (enable the comparator via `comparator_v2` flag if it is disabled) to run Polling, Trigger, and Log side by side.
+3. Pick one of the curated scenarios above, then adjust method-specific knobs:
+   - **Polling:** `poll_interval_ms`, soft-delete visibility.
+   - **Triggers:** trigger overhead sliders; enable `apply_on_commit` for multi-table writes.
+   - **Log:** WAL/binlog fetch interval; schema evolution toggles.
+4. Use the **Event Log** to filter by method and export NDJSON for downstream replay.
+5. Capture a screenshot or export the scenario to share reproducible demos with your team.

--- a/index.html
+++ b/index.html
@@ -100,6 +100,14 @@
                 >
                   Open evaluation checklist
                 </a>
+                <a
+                  class="btn-ghost"
+                  href="docs/cdc-method-cheatsheet.md"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Open method cheat sheet
+                </a>
               </div>
               <p class="hero-pathways-tip">
                 Want presets instead? Pick any scenario below to load schema,


### PR DESCRIPTION
## Summary
- add a concise CDC Method Cheat Sheet to guide polling vs trigger vs log vs outbox demos
- surface the cheat sheet in the hero actions alongside the evaluation checklist to keep resources handy
- refresh the README documentation roster so the new guide is discoverable

## Plan
1. Scan existing docs and hero actions for where users discover guidance resources.
2. Draft a new CDC method cheat sheet covering strengths, risks, and demo tips for Polling, Triggers, Log, and Outbox.
3. Link the cheat sheet from the hero CTA cluster and README documentation list for visibility.
4. Run feature-flag alignment check to ensure no regressions in the static shell.
5. Summarize changes with follow-up considerations and ship as a draft for review.

## Changes
- add `docs/cdc-method-cheatsheet.md` with method-by-method guidance and playground usage steps
- link the cheat sheet from the hero CTA block in `index.html`
- reference the cheat sheet in the README documentation section

## Verification
Commands:
```
npm run lint:flags
```
Evidence:
- Feature flag alignment check passes after the doc/link additions.

## Risks & Mitigations
- New link in the hero might crowd the CTA row → kept as a ghost button consistent with existing actions.

## Follow-ups
- Consider surfacing the cheat sheet inside the comparator shell (e.g., help panel) for in-app access.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d44beb56c83239add9254a73832d9)