### PR TITLE
fix: propagate txn metadata through polling adapter

### DIFF
--- a/src/modes/queryBased.test.ts
+++ b/src/modes/queryBased.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import type { Event } from "../domain/types";
+import { MetricsStore } from "../engine/metrics";
+import type { EventBus } from "../engine/eventBus";
+import type { Scheduler } from "../engine/scheduler";
+import type { ModeRuntime } from "./types";
+import { createQueryBasedAdapter } from "./queryBased";
+
+describe("queryBased adapter", () => {
+  it("propagates transaction metadata for polling events", () => {
+    const adapter = createQueryBasedAdapter();
+    const runtime: ModeRuntime = {
+      bus: {} as EventBus,
+      scheduler: {} as Scheduler,
+      metrics: new MetricsStore(),
+      topic: "cdc.test",
+    };
+
+    adapter.initialise?.(runtime);
+
+    const batches: Event[][] = [];
+    adapter.startTailing?.(events => {
+      batches.push(events);
+      return events;
+    });
+
+    adapter.applySource?.({
+      t: 300,
+      op: "insert",
+      table: "orders",
+      pk: { id: "ORD-720" },
+      after: { customer_id: "C-32", status: "pending", subtotal: 412.5 },
+      txn: { id: "TX-720", index: 0, total: 3 },
+    });
+    adapter.applySource?.({
+      t: 300,
+      op: "insert",
+      table: "order_items",
+      pk: { id: "ORD-720-1" },
+      after: { order_id: "ORD-720", sku: "SKU-9", qty: 2, price: 99.5 },
+      txn: { id: "TX-720", index: 1, total: 3 },
+    });
+    adapter.applySource?.({
+      t: 300,
+      op: "insert",
+      table: "order_items",
+      pk: { id: "ORD-720-2" },
+      after: { order_id: "ORD-720", sku: "SKU-44", qty: 1, price: 213.5 },
+      txn: { id: "TX-720", index: 2, total: 3, last: true },
+    });
+
+    adapter.tick?.(1000);
+
+    expect(batches).toHaveLength(1);
+    const events = batches[0];
+    expect(events).toHaveLength(3);
+
+    expect(events.map(event => event.txnId)).toEqual(["TX-720", "TX-720", "TX-720"]);
+    expect(events.map(event => event.txnIndex)).toEqual([0, 1, 2]);
+    expect(events.map(event => event.txnTotal)).toEqual([3, 3, 3]);
+    expect(events.map(event => event.txnLast)).toEqual([false, false, true]);
+  });
+});

--- a/src/modes/queryBased.ts
+++ b/src/modes/queryBased.ts
@@ -14,6 +14,7 @@ type StoredRow = {
   version: number;
   updatedAt: number;
   deleted: boolean;
+  txn?: SourceOp["txn"];
 };
 
 let eventSeq = 0;
@@ -167,6 +168,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
             version: 1,
             updatedAt: row.__ts ?? 0,
             deleted: false,
+            txn: undefined,
           });
           lastEmittedVersion.set(key, 1);
           const { id, __ts, ...rest } = row as { id: string; __ts?: number; [key: string]: unknown };
@@ -205,6 +207,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
           version: 1,
           updatedAt: commitTs,
           deleted: false,
+          txn: op.txn,
         });
       } else if (op.op === "update") {
         const current = rows.get(key);
@@ -216,6 +219,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
           version: (current?.version ?? 0) + 1,
           updatedAt: commitTs,
           deleted: false,
+          txn: op.txn,
         });
       } else if (op.op === "delete") {
         const current = rows.get(key);
@@ -226,6 +230,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
           version: (current?.version ?? 0) + 1,
           updatedAt: commitTs,
           deleted: true,
+          txn: op.txn,
         });
       }
     },
@@ -273,6 +278,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
                 null,
                 row.updatedAt,
                 `tx-${row.updatedAt}`,
+                row.txn,
               ),
             );
             lastEmittedVersion.set(key, row.version);
@@ -293,6 +299,7 @@ export function createQueryBasedAdapter(): ModeAdapter {
             clonePayload(row.data),
             row.updatedAt,
             `tx-${row.updatedAt}`,
+            row.txn,
           ),
         );
         lastEmittedVersion.set(key, row.version);


### PR DESCRIPTION
## Summary
- store the source transaction metadata on each buffered row inside the query-based adapter so polling emits complete batches when apply-on-commit is enabled
- include the stored metadata when building DELETE/INSERT/UPDATE events so `takeNextTransaction` can detect batch boundaries correctly
- add a vitest that reproduces the orders/items multi-table transaction to prove the metadata flows through Polling

## Plan
1. Reproduce the drift failure and inspect Polling lane snapshots/history.
2. Audit `drainQueues`/`takeNextTransaction` usage to confirm batching depends on txn metadata.
3. Update the query-based adapter to retain SourceOp transaction fields on stored rows.
4. Pass the stored metadata into the emitted events for all change kinds.
5. Add a unit test covering the multi-table transaction scenario and rerun the suite.

## Changes
- src/modes/queryBased.ts
- src/modes/queryBased.test.ts

## Verification
Commands:
```
npm run test:unit
npm run test:e2e -- tests/e2e/transaction-drift.spec.mjs
```
Evidence:
- `npm run test:unit`
- `npm run test:e2e -- tests/e2e/transaction-drift.spec.mjs` *(fails: Playwright cannot download Chromium in this environment; browsers are unavailable so the suite cannot launch)*

## Risks & Mitigations
- Query-based adapter emits txn metadata incorrectly → covered with a focused unit test for the multi-table scenario.

## Follow-ups
- Re-run the E2E `transaction-drift` spec once Playwright browsers can be installed to confirm Polling history stays atomic.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dff82d7d083238e99c182715390e9)