### PR TITLE
fix: clarify preview blueprint selector label

### DIFF
--- a/src/test/unit/playgroundCorePreview.test.tsx
+++ b/src/test/unit/playgroundCorePreview.test.tsx
@@ -49,7 +49,7 @@ describe("PlaygroundCorePreview", () => {
 
   it("shows scenario selector options", () => {
     render(<PlaygroundCorePreview scenarios={[demoScenario]} />);
-    const select = screen.getByLabelText(/Scenario/i) as HTMLSelectElement;
+    const select = screen.getByLabelText(/Preview blueprint/i) as HTMLSelectElement;
     expect(select.value).toBe("demo");
   });
 });

--- a/web/components/PlaygroundCorePreview.tsx
+++ b/web/components/PlaygroundCorePreview.tsx
@@ -168,8 +168,12 @@ export function PlaygroundCorePreview({ scenarios, autoStart = false }: { scenar
         <div className="sim-core__toolbar-row">
           <div className="sim-core__toolbar-group">
             <label>
-              <span className="sim-core__label">Scenario</span>
-              <select value={scenarioId} onChange={event => setScenarioId(event.target.value)}>
+              <span className="sim-core__label">Preview blueprint</span>
+              <select
+                aria-label="Preview blueprint"
+                value={scenarioId}
+                onChange={event => setScenarioId(event.target.value)}
+              >
                 {scenarios.map(item => (
                   <option key={item.id} value={item.id}>
                     {item.label}


### PR DESCRIPTION
## Summary
Updated the preview selector label in the core comparator toolbar to differentiate it from the primary scenario picker and avoid strict Playwright queries colliding. Synced the unit test to assert against the renamed label. This improves accessibility by giving the preview combobox a unique name.

## Plan
1. Update the preview combobox label/aria-label to a unique description.
2. Adjust associated unit expectations to the new label.
3. Run comparator E2E coverage to confirm the strict query passes.

## Changes
- Renamed the PlaygroundCorePreview scenario select label/aria-label to "Preview blueprint".
- Updated the PlaygroundCorePreview unit test to query the new label.

## Verification
Commands:
```
npm run test:e2e -- tests/e2e/comparator.spec.mjs
```
Evidence:
- Playwright browsers are not installed in the container, so the command failed before execution.

## Risks & Mitigations
- Users may briefly wonder about the new label wording → kept the control location and functionality identical while clarifying its preview-only purpose.

## Follow-ups
- Install Playwright browsers (`npx playwright install`) and rerun E2E in a fully provisioned environment.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eade84ec88323a531fbabb290bb4b)