### PR TITLE
Show missing simulator bundle placeholder

### DIFF
--- a/assets/ui-shell-loader.js
+++ b/assets/ui-shell-loader.js
@@ -76,6 +76,13 @@
       '<p class="sim-shell__placeholder">Enable the comparator_v2 feature flag to load the CDC Method Comparator.</p>';
   }
 
+  function markMissingBundle() {
+    const root = document.getElementById("simShellRoot");
+    if (!root) return;
+    root.innerHTML =
+      '<p class="sim-shell__placeholder">Simulator preview unavailable. Run <code>npm run build:web</code> to generate comparator assets, then reload.</p>';
+  }
+
   async function loadShell() {
     try {
       await importGeneratedModule(bundleHref);
@@ -85,6 +92,7 @@
         "Simulator UI shell bundle missing. Run `npm run build:web` to generate assets/generated/ui-shell.js before loading the page.",
         error
       );
+      markMissingBundle();
     }
   }
 


### PR DESCRIPTION
## Summary
- add explicit fallback messaging when the comparator bundle fails to load so the simulator preview no longer hangs on the preparing state
- keep feature-flag handling intact while surfacing build instructions to generate ui-shell assets

## Plan
1. Update the UI shell loader to detect bundle load failures.
2. Render a user-facing placeholder that explains how to build the comparator assets.
3. Verify the placeholder path and keep existing feature-flag behavior.

## Changes
- assets/ui-shell-loader.js

## Verification
Commands:
```
Not run (not requested).
```
Evidence:
- Not run (not requested).

## Risks & Mitigations
- Risk: Placeholder copy may differ from other docs. Mitigation: Reuse existing placeholder styling and reference the standard build command.

## Follow-ups
- None.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb86d32b88323b6f8c24c98919696)