### PR TITLE
fix(loader): mount comparator + playground on static/HTTP hosting

### DIFF
--- a/assets/changefeed-playground-loader.js
+++ b/assets/changefeed-playground-loader.js
@@ -45,8 +45,16 @@
   async function importGeneratedModule(relativeHref) {
     const resolved = resolveHref(relativeHref);
 
-    if (assetHeaderEntries.length === 0) {
-      return import(/* @vite-ignore */ resolved);
+    // Prefer a native dynamic import so the browser resolves the bundle's
+    // relative cross-chunk imports (e.g. "./event-log-widget.js") against the
+    // bundle's own URL. The header-fetch + blob fallback below cannot resolve
+    // those (blob: URLs are non-hierarchical), so native import must win first.
+    try {
+      return await import(/* @vite-ignore */ resolved);
+    } catch (nativeError) {
+      if (assetHeaderEntries.length === 0) {
+        throw nativeError;
+      }
     }
 
     const headers = {};

--- a/assets/event-log-loader.js
+++ b/assets/event-log-loader.js
@@ -28,8 +28,15 @@
       }
     })();
 
-    if (assetHeaderEntries.length === 0) {
-      return import(/* @vite-ignore */ resolved);
+    // Prefer a native dynamic import so the browser resolves any relative
+    // cross-chunk imports against the bundle's own URL. The header-fetch + blob
+    // fallback below cannot resolve those (blob: URLs are non-hierarchical).
+    try {
+      return await import(/* @vite-ignore */ resolved);
+    } catch (nativeError) {
+      if (assetHeaderEntries.length === 0) {
+        throw nativeError;
+      }
     }
 
     const headers = {};

--- a/assets/sim-loader.js
+++ b/assets/sim-loader.js
@@ -28,8 +28,15 @@
       }
     })();
 
-    if (assetHeaderEntries.length === 0) {
-      return import(/* @vite-ignore */ resolved);
+    // Prefer a native dynamic import so the browser resolves any relative
+    // cross-chunk imports against the bundle's own URL. The header-fetch + blob
+    // fallback below cannot resolve those (blob: URLs are non-hierarchical).
+    try {
+      return await import(/* @vite-ignore */ resolved);
+    } catch (nativeError) {
+      if (assetHeaderEntries.length === 0) {
+        throw nativeError;
+      }
     }
 
     const headers = {};

--- a/assets/ui-shell-loader.js
+++ b/assets/ui-shell-loader.js
@@ -50,7 +50,7 @@
   async function importGeneratedModule(relativeHref) {
     const resolved = resolveHref(relativeHref);
 
-    const shouldFetchWithHeaders = (() => {
+    const canFetchWithHeaders = (() => {
       if (assetHeaderEntries.length === 0) return false;
       try {
         const url = new URL(resolved, scriptBase);
@@ -60,8 +60,22 @@
       }
     })();
 
-    if (!shouldFetchWithHeaders) {
-      return import(/* @vite-ignore */ resolved);
+    // Prefer a native dynamic import: the browser resolves the bundle's
+    // relative cross-chunk imports (e.g. "./event-log-widget.js") against the
+    // bundle's own URL. This is the path that works for static hosting,
+    // Appwrite Sites (public assets), GitHub Pages, and `open index.html`.
+    try {
+      return await import(/* @vite-ignore */ resolved);
+    } catch (nativeError) {
+      // Native import only fails when the host genuinely refuses the request
+      // (e.g. a CDN that requires custom headers). Fall back to a
+      // header-authenticated fetch + blob import. NOTE: blob: URLs have a
+      // non-hierarchical base, so a code-split bundle that imports sibling
+      // chunks relatively will still fail here — keep the web bundles
+      // self-contained, or this fallback cannot help them.
+      if (!canFetchWithHeaders) {
+        throw nativeError;
+      }
     }
 
     const headers = {};

--- a/docs/AGENT_TEAM_BRIEF.md
+++ b/docs/AGENT_TEAM_BRIEF.md
@@ -1,0 +1,120 @@
+# Agent Team Brief — Make This the Best Place to Learn CDC
+
+**Date:** 2026-06-07
+**Prepared by:** state evaluation + critical-bug fix pass
+**North star:** A **newcomer to change data capture** lands here knowing nothing and leaves understanding what CDC is, why it matters, and how polling / trigger / log / outbox differ — by *doing*, not just reading.
+
+This brief is the entry point for a team of agents. Read it first. It captures the verified state of the repo, what was just fixed, and a prioritized, parallelizable backlog with acceptance criteria and known traps.
+
+---
+
+## 1. Verified state (empirical, this pass)
+
+Everything below was actually run, not inferred from docs.
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| `npm run build` | ✅ | sim + web bundles build clean |
+| `npm run test:unit` | ✅ | 95/95 pass |
+| `npm run test:sim` (property) | ✅ | 24/24 pass |
+| `npm run test:e2e` | ✅ | 8/8 pass (was "broken" only because Playwright browsers weren't installed — run `npx playwright install`) |
+| `lint:flags`, `lint:scenarios`, `check:bundles` | ✅ | green on a clean tree |
+| `npm audit --omit=dev` | ✅ | 0 prod vulnerabilities (the 10 reported are all dev-only) |
+| Canonical Docker scenario (`scenarios/01-canonical-reference/`) | ✅ built, ⚠️ unverified live | ~3,700 LOC, real images, working verifier/sink/dashboard/failure-injectors. Needs a live `make up` run (Docker required) to confirm end-to-end. |
+
+**The engineering foundation is solid.** The gaps are (a) one class of deploy-time bug that tests didn't cover, now fixed, and (b) the *learning experience* itself.
+
+---
+
+## 2. What this pass fixed (start from a working baseline)
+
+Two independent breakages made the two flagship interactive tools fail **on the deployed/static-hosted site**, while every test stayed green.
+
+### Fix A — comparator + playground broke on HTTP hosting (blob-import bug)
+- **Symptom:** `#simShellRoot` stuck on "Simulator preview unavailable"; `#changefeedPlaygroundRoot` stuck on "Preparing…".
+- **Root cause:** `index.html` hardcodes `window.APPWRITE_CFG.assetHeaders`, which forced the loaders (`assets/*-loader.js`) to fetch bundles as text and `import()` them via a **`blob:` URL**. The web bundles are code-split — `ui-shell.js` and `changefeed-playground.js` both `import … from "./event-log-widget.js"` — and a relative specifier cannot resolve against a non-hierarchical `blob:` base. → `TypeError: Failed to resolve module specifier "./event-log-widget.js"`.
+- **Why tests missed it:** unit/e2e load bundles directly as modules or over `file://`; the header/blob path only activates on `http(s)://`. **The deployed path had zero coverage.**
+- **Fix:** all four loaders (`ui-shell-loader.js`, `changefeed-playground-loader.js`, `event-log-loader.js`, `sim-loader.js`) now try a native `import()` first and only fall back to the header/blob fetch if native import actually throws.
+
+### Fix B — Change Feed Playground was never booted
+- **Symptom:** even with Fix A, `#changefeedPlaygroundRoot` stayed on "Preparing…".
+- **Root cause:** `changefeed-playground-loader.js` only *exposes* a `.load()` handle; nothing in `index.html` or `assets/app.js` ever called it (compare: the event-log widget is booted from `app.js`). So the bundle was never imported.
+- **Fix:** added an idle-time bootstrap in `index.html` that calls `window.__LetstalkCdcChangefeedPlayground.load()` (the bundle self-mounts on import).
+
+### Regression guard added
+- `tests/e2e/static-hosting-smoke.spec.mjs` — spins up a real HTTP static server (reproducing the hardcoded-Appwrite-headers condition) and asserts both widgets mount with no loader warnings. **This is the test the project was missing.** Keep it green.
+
+> ⚠️ **Trap for the team:** any change that re-introduces a code-split shared chunk imported through the blob path, or that strips the changefeed bootstrap, will silently break the live site again while `file://` specs pass. The smoke test is the canary — do not delete or weaken it.
+
+---
+
+## 3. Workstreams (parallelizable — one agent or small pod each)
+
+Priority order: **W1 → (W2 ∥ W3 ∥ W5) → W4.** W1 is mostly done; verify and extend it. The rest are independent and can run concurrently.
+
+### W1 — Reliability & deploy correctness (mostly done — verify + extend)
+- [ ] **Verify the fix on the real deploy target.** Run `npm run package:appwrite`, deploy to Appwrite Sites, confirm both widgets mount in the live browser. Repeat for the GitHub Pages mirror (`girhun.github.io/...`).
+- [ ] **Run the canonical Docker scenario live** (`cd scenarios/01-canonical-reference && make preflight && make up && make status`). Capture what actually happens vs `docs/expected-behavior.md`. File any drift.
+- [ ] **Reconsider the hardcoded `APPWRITE_CFG.assetHeaders`** in `index.html` — is the `X-Appwrite-Project` header even required to fetch public static assets? If not, removing it simplifies the loader path entirely. Acceptance: documented decision + smoke test still green.
+- [ ] Wire the new smoke spec into `ci:preflight` (it already runs under `test:e2e`).
+
+### W2 — Newcomer on-ramp (highest learning leverage; audience = beginners)
+There is **no path for someone who doesn't already know CDC.** Build it.
+- [ ] **`docs/what-is-cdc.md`** — plain-language "Why CDC?": use cases (analytics, event sourcing, microservices, cache invalidation), CDC vs batch ELT, when *not* to use it. Link from the top of `README.md` and the site hero.
+- [ ] **`docs/glossary.md`** — define every term the UI/docs throw at learners: LSN, WAL, binlog, offset, slot, snapshot, tombstone, soft delete, apply-on-commit, commit drift, write amplification, dedupe, outbox. Cross-link from docs and wire into the existing `ff_walkthrough` tooltip system.
+- [ ] **`docs/learning-path.md`** — an explicit beginner → intermediate → advanced sequence that threads the existing strong assets (`cdc-method-cheatsheet.md` → `cdc-demo-playbook.md` → `cdc-lab-recipes.md` → `canonical-scenario.md`).
+- [ ] **A "What is CDC?" moment in the site hero** (`index.html`) — one screen that orients a first-timer before they hit a pile of controls.
+- **Acceptance:** a reader who has never heard of CDC can follow a single linked trail from the README to running the canonical scenario without getting stuck on undefined jargon.
+
+### W3 — UX / information architecture
+- [ ] **Disambiguate the two simulators.** The page has both a "Change Feed Playground" (simple 3-lane) and a "CDC Method Comparator" (dense, multi-feature) with no signpost for which to use first. Decide: tutorial-then-tool, or merge. Add in-context framing either way.
+- [ ] **Difficulty tags on scenarios** (`assets/shared-scenarios.js`) — Beginner / Intermediate / Advanced, surfaced in the gallery filter, so a learner doesn't open "Orders + Items Transactions" first.
+- [ ] **In-comparator onboarding** — the comparator drops users straight into scenario selection with no explanation of lanes, lag, ordering, or write amplification. Add a first-run guided overlay (the `ff_walkthrough` flag already exists).
+- [ ] **Replace bare "Preparing…/unavailable" placeholders** with real loading states + actionable fallbacks.
+- [ ] **Mobile/responsive pass** on the 3-lane views.
+
+### W4 — Content depth (after the on-ramp exists)
+Strong hands-on content already exists (demo playbook, lab recipes, canonical scenario). Fill the topic gaps:
+- [ ] Exactly-once vs at-least-once (currently only mentioned in passing).
+- [ ] Schema registry & compatibility modes (hands-on, not just a warning).
+- [ ] Sink design patterns (upsert semantics, dedupe strategies, idempotency) as a standalone doc.
+- [ ] Cross-database CDC (Postgres vs MySQL vs Mongo) — at least a comparison.
+- [ ] Production runbooks: turn each canonical failure mode's recovery into a standalone checklist.
+
+### W5 — Repo hygiene & docs truth (quick wins)
+- [ ] **Delete `path/to/`** — two accidental 1-line placeholder files (`README.md`, `release-notes.md`) committed by mistake.
+- [ ] **Reconcile version drift** — `docs/next-steps.md` and `docs/IMPLEMENTATION_PLAN.md` still reference a "v1.0" that contradicts the `0.1.0` snapshot. Pick one source of truth.
+- [ ] **Add `docs/README.md` index** — 20+ docs across `docs/`, `docs/enablement/`, `docs/issues/` with no map. Index them by role/use-case.
+- [ ] Update `README.md` "Current Status" and the assessment docs to reflect this pass (E2E green, loader bug fixed).
+
+---
+
+## 4. Build / test / run cheat-sheet for agents
+
+```bash
+npm install
+npm run build            # sim + web bundles → assets/generated/
+npm run test:unit        # 95 tests (vitest)
+npm run test:sim         # 24 property invariants
+npx playwright install   # one-time, before e2e
+npm run test:e2e         # 8 specs incl. static-hosting smoke
+npm run lint:flags lint:scenarios check:bundles
+
+# See it for real (the bug only shows over HTTP, not file://):
+python3 -m http.server 4179   # then open http://localhost:4179/index.html
+```
+
+**Golden rule:** for anything touching the loaders, the bundle split, or `index.html` boot, verify over **HTTP** (not `file://` and not the vite dev server) — that's the only way to exercise the deployed path. The smoke test does this; so should you.
+
+---
+
+## 5. Key file map
+
+- `index.html` — single-page entry; hero, vanilla workspace, two React mount points (`#changefeedPlaygroundRoot`, `#simShellRoot`), feature flags, loader bootstraps.
+- `assets/*-loader.js` — hand-authored bundle loaders (NOT built; not bundle inputs).
+- `assets/app.js` — vanilla workspace logic + widget orchestration (~5,300 LOC).
+- `assets/shared-scenarios.js` — single source for the scenario gallery + comparator demos.
+- `web/` — React entries (`main.tsx` → comparator, `changefeed.tsx` → playground, `event-log-widget.tsx`).
+- `src/` — engine + domain + UI components (the real logic; `web/` re-exports).
+- `scenarios/01-canonical-reference/` — the Docker "Failure-Aware CDC Reference Pipeline" (the authoritative learning centerpiece).
+- `docs/` — learning content (strong on hands-on, thin on newcomer on-ramp).

--- a/index.html
+++ b/index.html
@@ -664,7 +664,12 @@
           if (booted) return;
           booted = true;
           const handle = window.__LetstalkCdcChangefeedPlayground;
-          if (!handle || typeof handle.load !== "function") return;
+          if (!handle || typeof handle.load !== "function") {
+            console.warn(
+              "Change feed playground loader handle missing — assets/changefeed-playground-loader.js did not load. The section will stay on its placeholder."
+            );
+            return;
+          }
           handle.load().catch((error) => {
             console.warn("Change feed playground unavailable", error);
           });

--- a/index.html
+++ b/index.html
@@ -654,6 +654,29 @@
     <script src="./assets/changefeed-playground-loader.js"></script>
     <script src="./assets/ui-shell-loader.js"></script>
     <script>
+      // Boot the Change Feed Playground. Its bundle self-mounts on import, but
+      // the loader only exposes a `.load()` handle — without this trigger the
+      // section sits on its "Preparing…" placeholder forever. Defer to idle so
+      // the base playground paints first, then mount unconditionally.
+      (() => {
+        let booted = false;
+        const boot = () => {
+          if (booted) return;
+          booted = true;
+          const handle = window.__LetstalkCdcChangefeedPlayground;
+          if (!handle || typeof handle.load !== "function") return;
+          handle.load().catch((error) => {
+            console.warn("Change feed playground unavailable", error);
+          });
+        };
+        if (typeof window.requestIdleCallback === "function") {
+          window.requestIdleCallback(boot, { timeout: 2000 });
+        } else {
+          window.setTimeout(boot, 600);
+        }
+      })();
+    </script>
+    <script>
       (() => {
         const DEFAULT_STATUS_TEXT = "Add a column to begin";
 

--- a/tests/e2e/static-hosting-smoke.spec.mjs
+++ b/tests/e2e/static-hosting-smoke.spec.mjs
@@ -13,7 +13,7 @@ const suite = process.env.PLAYWRIGHT_DISABLE === "1" ? test.describe.skip : test
 // file://. This is the condition under which `index.html`'s hardcoded
 // APPWRITE_CFG.assetHeaders activates the loaders' header path. A regression
 // in that path (e.g. importing code-split bundles via a non-hierarchical
-// blob: URL) breaks the comparator + changefeed playload on every deployed
+// blob: URL) breaks the comparator + changefeed playground on every deployed
 // site while file://-based specs stay green. This guards that gap.
 const CONTENT_TYPES = {
   ".html": "text/html; charset=utf-8",
@@ -34,8 +34,9 @@ suite("Static hosting smoke (served over HTTP)", () => {
       try {
         const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
         const relative = urlPath === "/" ? "index.html" : urlPath.replace(/^\/+/, "");
-        const filePath = path.join(repoRoot, relative);
-        if (!filePath.startsWith(repoRoot)) {
+        const filePath = path.resolve(repoRoot, relative);
+        const relToRoot = path.relative(repoRoot, filePath);
+        if (relToRoot.startsWith("..") || path.isAbsolute(relToRoot)) {
           res.writeHead(403).end("Forbidden");
           return;
         }
@@ -64,9 +65,14 @@ suite("Static hosting smoke (served over HTTP)", () => {
 
   test("comparator and changefeed playground mount on static HTTP hosting", async ({ page }) => {
     const loaderWarnings = [];
+    // Match only loader-specific failures, not unrelated "… unavailable"
+    // warnings (e.g. anonymous session, event log widget) that would make this
+    // smoke test flaky. These are the exact phrases the bundle loaders and the
+    // index.html changefeed bootstrap emit on failure.
+    const LOADER_FAILURE = /Simulator UI shell (?:load failed|bundle missing)|Changefeed[ -]playground (?:load failed|bundle missing)|Change feed playground unavailable|Failed to resolve module specifier/i;
     page.on("console", (msg) => {
       const text = msg.text();
-      if (/unavailable|bundle missing|Failed to resolve module specifier/i.test(text)) {
+      if (LOADER_FAILURE.test(text)) {
         loaderWarnings.push(text);
       }
     });

--- a/tests/e2e/static-hosting-smoke.spec.mjs
+++ b/tests/e2e/static-hosting-smoke.spec.mjs
@@ -1,0 +1,94 @@
+import { test, expect } from "@playwright/test";
+import { createServer } from "http";
+import { readFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "../..");
+
+const suite = process.env.PLAYWRIGHT_DISABLE === "1" ? test.describe.skip : test.describe;
+
+// Minimal static file server so the page is served over real HTTP(S), not
+// file://. This is the condition under which `index.html`'s hardcoded
+// APPWRITE_CFG.assetHeaders activates the loaders' header path. A regression
+// in that path (e.g. importing code-split bundles via a non-hierarchical
+// blob: URL) breaks the comparator + changefeed playload on every deployed
+// site while file://-based specs stay green. This guards that gap.
+const CONTENT_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+let server;
+let baseUrl;
+
+suite("Static hosting smoke (served over HTTP)", () => {
+  test.beforeAll(async () => {
+    server = createServer(async (req, res) => {
+      try {
+        const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+        const relative = urlPath === "/" ? "index.html" : urlPath.replace(/^\/+/, "");
+        const filePath = path.join(repoRoot, relative);
+        if (!filePath.startsWith(repoRoot)) {
+          res.writeHead(403).end("Forbidden");
+          return;
+        }
+        const body = await readFile(filePath);
+        const ext = path.extname(filePath).toLowerCase();
+        res.writeHead(200, { "Content-Type": CONTENT_TYPES[ext] || "application/octet-stream" });
+        res.end(body);
+      } catch {
+        res.writeHead(404).end("Not found");
+      }
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  test.afterAll(async () => {
+    if (server) await new Promise((resolve) => server.close(resolve));
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cdc_playground_onboarding_v1", "seen");
+    });
+  });
+
+  test("comparator and changefeed playground mount on static HTTP hosting", async ({ page }) => {
+    const loaderWarnings = [];
+    page.on("console", (msg) => {
+      const text = msg.text();
+      if (/unavailable|bundle missing|Failed to resolve module specifier/i.test(text)) {
+        loaderWarnings.push(text);
+      }
+    });
+
+    await page.goto(`${baseUrl}/index.html`, { waitUntil: "load" });
+
+    // The CDC Method Comparator must render (the blob-import regression left it
+    // stuck on a "Simulator preview unavailable" placeholder).
+    await expect(page.getByRole("heading", { name: /CDC Method Comparator/i })).toBeVisible({
+      timeout: 15000,
+    });
+
+    // The Change Feed Playground must mount too (it is never imported unless the
+    // index.html bootstrap calls its loader's .load() handle).
+    const changefeedRoot = page.locator("#changefeedPlaygroundRoot");
+    await expect(changefeedRoot).not.toContainText(/Preparing the change feed playground/i, {
+      timeout: 15000,
+    });
+    await expect(changefeedRoot.getByText(/Source\s*→\s*Change Feed\s*→\s*Consumer/i)).toBeVisible({
+      timeout: 15000,
+    });
+
+    expect(loaderWarnings, `loader warnings: ${loaderWarnings.join(" | ")}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The two flagship interactive tools — the **CDC Method Comparator** (`#simShellRoot`) and the **Change Feed Playground** (`#changefeedPlaygroundRoot`) — failed to load on **every deployed (http/https) site**, sitting on "Simulator preview unavailable" / "Preparing…" placeholders. The whole test suite stayed green throughout.

Two independent root causes, both fixed here.

### 1. Blob-import breaks the code-split bundles
`index.html` hardcodes `window.APPWRITE_CFG.assetHeaders`, which forced the loaders to fetch each bundle as text and `import()` it via a **`blob:` URL**. The web bundles are code-split — `ui-shell.js` and `changefeed-playground.js` both `import … from "./event-log-widget.js"` — and a relative specifier cannot resolve against a non-hierarchical `blob:` base:

> `TypeError: Failed to resolve module specifier "./event-log-widget.js". Invalid relative url or base scheme isn't hierarchical.`

All four loaders (`ui-shell-loader.js`, `changefeed-playground-loader.js`, `event-log-loader.js`, `sim-loader.js`) now try a **native `import()` first** and fall back to the header/blob fetch only if native import actually throws.

### 2. The Change Feed Playground was never booted
Its loader only *exposed* a `.load()` handle — nothing in `index.html` or `app.js` ever called it (unlike the event-log widget, booted from `app.js`). Added an idle-time bootstrap in `index.html`; the bundle self-mounts on import.

## Why tests didn't catch it
Unit/E2E load bundles over `file://` or as direct modules. The header/blob path only activates on `http(s)://`, so the **deployed path had zero coverage**. This PR adds `tests/e2e/static-hosting-smoke.spec.mjs`, which serves the site over real HTTP (reproducing the hardcoded-headers condition) and asserts both widgets mount with no loader warnings.

## Verification
- ✅ Reproduced the failure in a real browser, then confirmed both widgets mount after the fix (with Appwrite headers still configured).
- ✅ `test:e2e` 8/8 (incl. new smoke test), `test:unit` 95/95, `test:sim` 24/24, lint all green.

## Also included
`docs/AGENT_TEAM_BRIEF.md` — verified project state, this fix (so it isn't re-broken), and a prioritized, parallelizable backlog for turning this into a great CDC learning resource (newcomer on-ramp, UX/IA, content depth, hygiene).

> ⚠️ Anything touching the loaders, the bundle split, or `index.html` boot must be verified over **HTTP**, not `file://`. The smoke test is the canary — keep it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)