### PR TITLE
W3 UX: scenario difficulty filter + disambiguate the two simulators

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -841,6 +841,7 @@ const uiState = {
   lastShareId: null,
   scenarioFilter: "",
   scenarioTags: [],
+  scenarioDifficulty: null, // null = all; otherwise "beginner" | "intermediate" | "advanced"
   previewTemplate: null,
   pendingShareId: (() => {
     if (typeof window === "undefined") return null;
@@ -1166,6 +1167,7 @@ function renderTemplateGallery() {
 
   const filter = (uiState.scenarioFilter || "").trim().toLowerCase();
   const templates = SCENARIO_TEMPLATES.filter(template => {
+    if (uiState.scenarioDifficulty && template.difficulty !== uiState.scenarioDifficulty) return false;
     if (!matchesTagFilters(template)) return false;
     if (!filter) return true;
     const haystack = [
@@ -1410,9 +1412,52 @@ function matchesTagFilters(template) {
   return uiState.scenarioTags.every(tag => template.tags.includes(tag));
 }
 
+const DIFFICULTY_FILTER_ORDER = ["beginner", "intermediate", "advanced"];
+
+function renderDifficultyFilter() {
+  if (!els.templateTagBar) return;
+  const available = DIFFICULTY_FILTER_ORDER.filter(level =>
+    SCENARIO_TEMPLATES.some(template => template.difficulty === level)
+  );
+  if (available.length < 2) return; // nothing meaningful to filter by
+
+  const group = document.createElement("div");
+  group.className = "template-difficulty-filter";
+  group.setAttribute("role", "group");
+  group.setAttribute("aria-label", "Filter scenarios by difficulty");
+
+  available.forEach(level => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    const isActive = uiState.scenarioDifficulty === level;
+    btn.className = `template-tag template-difficulty-chip template-difficulty-chip--${level}`;
+    btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+    btn.textContent = DIFFICULTY_LABELS[level];
+    btn.onclick = () => toggleScenarioDifficulty(level);
+    group.appendChild(btn);
+  });
+
+  els.templateTagBar.appendChild(group);
+}
+
+function toggleScenarioDifficulty(level) {
+  uiState.scenarioDifficulty = uiState.scenarioDifficulty === level ? null : level;
+  renderTemplateGallery();
+  window.dispatchEvent(new CustomEvent("cdc:scenario-filter", {
+    detail: {
+      query: uiState.scenarioFilter,
+      tags: uiState.scenarioTags,
+      difficulty: uiState.scenarioDifficulty,
+    },
+  }));
+}
+
 function renderTemplateTags(allTags) {
   if (!els.templateTagBar) return;
   els.templateTagBar.innerHTML = "";
+
+  renderDifficultyFilter();
+
   if (!allTags.length) return;
 
   allTags.forEach(tag => {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -970,33 +970,36 @@ body[data-theme="light"] .template-card__difficulty--advanced {
   font-weight: 600;
 }
 
-.template-difficulty-chip--beginner[aria-pressed="true"] {
+/* Qualify with `.template-tag` so these win over the generic
+   `.template-tag[aria-pressed="true"]` rule defined later in this file
+   (otherwise active difficulty chips fall back to the blue tag styling). */
+.template-tag.template-difficulty-chip--beginner[aria-pressed="true"] {
   background: rgba(34, 197, 94, 0.24);
   border-color: rgba(34, 197, 94, 0.55);
   color: #9be8b5;
 }
 
-.template-difficulty-chip--intermediate[aria-pressed="true"] {
+.template-tag.template-difficulty-chip--intermediate[aria-pressed="true"] {
   background: rgba(234, 179, 8, 0.24);
   border-color: rgba(234, 179, 8, 0.55);
   color: #f3da8c;
 }
 
-.template-difficulty-chip--advanced[aria-pressed="true"] {
+.template-tag.template-difficulty-chip--advanced[aria-pressed="true"] {
   background: rgba(239, 68, 68, 0.24);
   border-color: rgba(239, 68, 68, 0.55);
   color: #f6b1b1;
 }
 
-body[data-theme="light"] .template-difficulty-chip--beginner[aria-pressed="true"] {
+body[data-theme="light"] .template-tag.template-difficulty-chip--beginner[aria-pressed="true"] {
   color: #15803d;
 }
 
-body[data-theme="light"] .template-difficulty-chip--intermediate[aria-pressed="true"] {
+body[data-theme="light"] .template-tag.template-difficulty-chip--intermediate[aria-pressed="true"] {
   color: #a16207;
 }
 
-body[data-theme="light"] .template-difficulty-chip--advanced[aria-pressed="true"] {
+body[data-theme="light"] .template-tag.template-difficulty-chip--advanced[aria-pressed="true"] {
   color: #b91c1c;
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -945,6 +945,61 @@ body[data-theme="light"] .template-card__difficulty--advanced {
   color: #b91c1c;
 }
 
+.template-tag-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 12px 0 4px;
+}
+
+.template-tag-bar:empty {
+  display: none;
+}
+
+/* Difficulty filter chips in the scenario gallery tag bar */
+.template-difficulty-filter {
+  display: inline-flex;
+  gap: 6px;
+  margin-right: 4px;
+  padding-right: 8px;
+  border-right: 1px solid rgba(82, 114, 169, 0.4);
+}
+
+.template-difficulty-chip {
+  font-weight: 600;
+}
+
+.template-difficulty-chip--beginner[aria-pressed="true"] {
+  background: rgba(34, 197, 94, 0.24);
+  border-color: rgba(34, 197, 94, 0.55);
+  color: #9be8b5;
+}
+
+.template-difficulty-chip--intermediate[aria-pressed="true"] {
+  background: rgba(234, 179, 8, 0.24);
+  border-color: rgba(234, 179, 8, 0.55);
+  color: #f3da8c;
+}
+
+.template-difficulty-chip--advanced[aria-pressed="true"] {
+  background: rgba(239, 68, 68, 0.24);
+  border-color: rgba(239, 68, 68, 0.55);
+  color: #f6b1b1;
+}
+
+body[data-theme="light"] .template-difficulty-chip--beginner[aria-pressed="true"] {
+  color: #15803d;
+}
+
+body[data-theme="light"] .template-difficulty-chip--intermediate[aria-pressed="true"] {
+  color: #a16207;
+}
+
+body[data-theme="light"] .template-difficulty-chip--advanced[aria-pressed="true"] {
+  color: #b91c1c;
+}
+
 .template-card__summary {
   margin: 0;
   color: var(--muted);
@@ -3661,4 +3716,15 @@ body.megadesk-mode .hero-ambient .orb {
   margin: 6px 0 0;
   color: #bac8e6;
   line-height: 1.5;
+}
+
+.section-lead--muted {
+  font-size: 13px;
+  color: var(--muted, #93a4c8);
+}
+
+.section-lead--muted a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }

--- a/index.html
+++ b/index.html
@@ -150,6 +150,12 @@
               />
             </div>
           </header>
+          <div
+            class="template-tag-bar"
+            id="templateTagBar"
+            role="group"
+            aria-label="Filter scenarios by difficulty and tag"
+          ></div>
           <div class="template-grid" id="templateGallery"></div>
         </div>
       </section>
@@ -452,13 +458,18 @@
       >
         <div class="section-title-row">
           <div>
-            <p class="section-eyebrow">Playground core</p>
+            <p class="section-eyebrow">Single feed · Start here</p>
             <h2 id="changefeedPlaygroundTitle" class="section-title">
               Change Feed Atomicity Playground
             </h2>
             <p class="section-lead">
               Three-lane view of source rows, change feed partitions, and consumer apply policies. Toggle drift, drop faults,
               and backlog throttling to see how transactions behave.
+            </p>
+            <p class="section-lead section-lead--muted">
+              Best for understanding <strong>one</strong> change feed end to end. To compare polling, trigger, and
+              log capture side by side, jump to the
+              <a href="#sim-shell-preview">CDC Method Comparator</a> below.
             </p>
           </div>
           <div class="section-actions" role="group" aria-label="Playground actions">
@@ -479,12 +490,18 @@
       >
         <div class="section-title-row">
           <div>
+            <p class="section-eyebrow">Compare methods · Go deeper</p>
             <h2 id="simShellTitle" class="section-title">
-              CDC Method Preview (beta)
+              Compare CDC Capture Methods (beta)
             </h2>
             <p class="section-lead">
               Load the CDC Method Comparator to see how polling, trigger, and
               log-based capture respond as you run the same operations.
+            </p>
+            <p class="section-lead section-lead--muted">
+              Use this after the
+              <a href="#changefeed-playground">playground above</a> when you want to contrast capture
+              <strong>strategies</strong> rather than trace a single feed.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Continues the W3 simulator-UX workstream from the agent brief. Built on a fresh branch off `main` (after #276 merged).

## 1. Scenario difficulty filter
Beginner/Intermediate/Advanced filter chips above the scenario gallery, complementing the difficulty badges from #276. Single-select; click the active chip to clear.

- Verified: Beginner → 1 card, Intermediate → 5, Advanced → 5, clear → 11.
- **Bonus fix:** surfacing the filter required adding the missing `#templateTagBar` element to `index.html`. That element never existed, so `renderTemplateTags` had been a **silent no-op** — this also revives the previously-dead `#tag` chips.

## 2. Disambiguate the two simulators
The page has two tools with no signpost for which to use first (a gap the brief's W3 called out):

- **Order eyebrows:** "Single feed · Start here" (Change Feed Atomicity Playground) vs "Compare methods · Go deeper" (the comparator section).
- **Cross-links** between the two sections explaining how they differ.
- Renamed the comparator section heading "CDC Method Preview" → **"Compare CDC Capture Methods (beta)"** — clearer, and deliberately *not* identical to the mounted tool's own "CDC Method Comparator" heading (a duplicate-heading a11y issue, and it would shadow the e2e locator).

## Scope
Only hand-authored static files (`index.html`, `assets/app.js`, `assets/styles.css`) — **no vite build inputs**, so generated bundles are unchanged. Stays in the simulator's lane per the brief (no education content; the hero still links out to `letstalkcdc`).

## Verification
95 unit + 8 e2e green (incl. the static-hosting smoke test). Built/tested on Node 20 to match CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)