### PR TITLE
W3 UX: real loading states + learner-friendly failure fallbacks

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3615,6 +3615,66 @@ body.megadesk-mode .hero-ambient .orb {
   color: #94a3b8;
 }
 
+.sim-shell__placeholder--error {
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.1);
+  color: #f1c4c4;
+}
+
+.sim-shell__placeholder-actions {
+  margin: 10px 0 0;
+}
+
+.sim-shell__btn {
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(147, 197, 253, 0.45);
+  background: rgba(37, 99, 235, 0.2);
+  color: #dbeafe;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sim-shell__btn:hover {
+  background: rgba(37, 99, 235, 0.32);
+}
+
+/* Loading state shown while a simulator bundle is being fetched/mounted. */
+.sim-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+  padding: 18px 20px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.6);
+  color: #94a3b8;
+  font-size: 14px;
+}
+
+.sim-loading__spinner {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.3);
+  border-top-color: #93c5fd;
+  animation: sim-loading-spin 0.8s linear infinite;
+}
+
+@keyframes sim-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sim-loading__spinner {
+    animation-duration: 2.4s;
+  }
+}
+
 @media (max-width: 600px) {
   .schema {
     display: flex;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3671,7 +3671,7 @@ body.megadesk-mode .hero-ambient .orb {
 
 @media (prefers-reduced-motion: reduce) {
   .sim-loading__spinner {
-    animation-duration: 2.4s;
+    animation: none;
   }
 }
 

--- a/assets/ui-shell-loader.js
+++ b/assets/ui-shell-loader.js
@@ -124,10 +124,9 @@
     if (!root) return;
     root.innerHTML =
       '<div class="sim-shell__placeholder">' +
-      '<p>Enable the comparator_v2 feature flag to load the CDC Method Comparator.</p>' +
+      "<p>The CDC Method Comparator is turned off. Turn it on to compare polling, trigger, and log capture side by side.</p>" +
       '<p class="sim-shell__placeholder-actions">' +
-      '<button type="button" id="simShellEnableFlag">Enable & retry</button>' +
-      " <span aria-live=\"polite\">(Note: Previously saved flag state may override this setting)</span>" +
+      '<button type="button" class="sim-shell__btn" id="simShellEnableFlag">Turn on comparator</button>' +
       "</p>" +
       "</div>";
 
@@ -152,10 +151,21 @@
     const root = document.getElementById("simShellRoot");
     if (!root) return;
     root.innerHTML =
-      '<div class="sim-shell__placeholder">' +
-      '<p>Simulator preview unavailable. Run <code>npm run build:web</code> to generate comparator assets, then reload.</p>' +
-      `<p class="sim-shell__placeholder-actions">Tried: ${candidateHrefs(bundleHref).join(", ")}</p>` +
+      '<div class="sim-shell__placeholder sim-shell__placeholder--error" role="alert">' +
+      "<p>The CDC Method Comparator couldn't load — this is usually a temporary network hiccup.</p>" +
+      '<p class="sim-shell__placeholder-actions">' +
+      '<button type="button" class="sim-shell__btn" id="simShellRetry">Retry</button>' +
+      "</p>" +
       "</div>";
+    // Technical detail stays in the console for maintainers, not the learner UI.
+    console.warn(
+      "Simulator UI shell bundle could not be loaded. Tried:",
+      candidateHrefs(bundleHref).join(", ")
+    );
+    const retry = document.getElementById("simShellRetry");
+    if (retry) {
+      retry.addEventListener("click", () => global.location.reload(), { once: true });
+    }
   }
 
   async function loadShell() {

--- a/index.html
+++ b/index.html
@@ -479,7 +479,10 @@
           </div>
         </div>
         <div id="changefeedPlaygroundRoot" class="playground-react-root">
-          <p class="sim-shell__placeholder">Preparing the change feed playground…</p>
+          <div class="sim-loading" role="status" aria-live="polite">
+            <span class="sim-loading__spinner" aria-hidden="true"></span>
+            <span class="sim-loading__text">Loading the change feed playground…</span>
+          </div>
         </div>
       </section>
 
@@ -506,7 +509,10 @@
           </div>
         </div>
         <div id="simShellRoot">
-          <p>Preparing simulator preview…</p>
+          <div class="sim-loading" role="status" aria-live="polite">
+            <span class="sim-loading__spinner" aria-hidden="true"></span>
+            <span class="sim-loading__text">Loading the CDC method comparator…</span>
+          </div>
         </div>
         <div
           id="methodGuidance"
@@ -695,6 +701,18 @@
           }
           handle.load().catch((error) => {
             console.warn("Change feed playground unavailable", error);
+            const root = document.getElementById("changefeedPlaygroundRoot");
+            if (!root) return;
+            root.innerHTML =
+              '<div class="sim-shell__placeholder sim-shell__placeholder--error" role="alert">' +
+              "<p>The change feed playground couldn't load — this is usually a temporary network hiccup.</p>" +
+              '<p class="sim-shell__placeholder-actions">' +
+              '<button type="button" class="sim-shell__btn" id="changefeedRetry">Retry</button>' +
+              "</p></div>";
+            const retry = document.getElementById("changefeedRetry");
+            if (retry) {
+              retry.addEventListener("click", () => window.location.reload(), { once: true });
+            }
           });
         };
         if (typeof window.requestIdleCallback === "function") {


### PR DESCRIPTION
Continues the W3 simulator-UX workstream. Replaces the bare "Preparing…/unavailable" placeholders (the brief's last in-repo W3 item I can fully verify here).

## Before
- Both simulator mounts showed static `Preparing…` text — no indication anything was happening.
- On bundle-load failure the learner was told to *"Run `npm run build:web`"* (a dev command) and shown a dump of internal candidate URLs.
- The change feed playground, on failure, silently sat on its placeholder forever.

## After
- **Loading state:** animated spinner + clear copy for both `#changefeedPlaygroundRoot` and `#simShellRoot` (`role="status"`, `aria-live="polite"`, honors `prefers-reduced-motion`).
- **Comparator load failure:** plain-language "couldn't load — usually a temporary hiccup" + a **Retry** button. The tried-URLs detail moves to `console.warn` for maintainers, out of the learner UI.
- **Comparator off:** "Enable the comparator_v2 feature flag" → "Turn on comparator".
- **Change feed failure:** the idle bootstrap now renders the same error + Retry fallback instead of leaving a stuck spinner.

## Scope / verification
Hand-authored static files only (`index.html`, `assets/styles.css`, `assets/ui-shell-loader.js`) — **no vite inputs**, generated bundles unchanged. Verified in-browser: both mount on the happy path; spinner animation wired (`sim-loading-spin`); error fallback renders with `role="alert"` + styled Retry. 95 unit + 8 e2e green (Node 20, matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)