### PR TITLE
W3 UX: mobile pass — stack section headers on phones

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1589,14 +1589,17 @@ body[data-theme="light"] .hero-ambient .orb-three {
 
   /* Stack section headers so titles/eyebrows get full width instead of
      competing with the action pills, which otherwise cram into a narrow
-     column on phones. */
-  .section-title-row {
+     column on phones. Qualified with .workspace-panel (specificity 0-2-0)
+     so these win over the later non-media .section-title-row base rule —
+     media queries don't add specificity, so a bare selector would lose on
+     source order. */
+  .workspace-panel .section-title-row {
     flex-direction: column;
     align-items: flex-start;
     gap: 12px;
   }
 
-  .section-actions {
+  .workspace-panel .section-actions {
     display: flex;
     flex-wrap: wrap;
     gap: 8px;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1586,6 +1586,21 @@ body[data-theme="light"] .hero-ambient .orb-three {
     max-width: 100%;
     box-sizing: border-box;
   }
+
+  /* Stack section headers so titles/eyebrows get full width instead of
+     competing with the action pills, which otherwise cram into a narrow
+     column on phones. */
+  .section-title-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .section-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
 }
 
 .card {


### PR DESCRIPTION
Continues the W3 simulator-UX workstream with a mobile/responsive pass on the landing page.

## Audit (375px)
Good news first: the page shell is already largely responsive — **zero horizontal page overflow** at mobile width. The scenario gallery collapses to one column, the topbar action buttons (Export/Import/Reset) wrap, the difficulty + tag chip bar wraps, hero pathways stack, and wide tables scroll within their own `overflow-x:auto` containers.

## The one real issue, fixed
`.section-title-row` stayed `flex-row` on phones, so the section title + eyebrow + the new disambiguation copy were squeezed into ~230px while the action pills crammed into a ~105px column. Now under 768px the header **stacks**: the title block takes full width and the pills lay out as a full-width wrapping row beneath it. Verified for both the Change Feed Playground and the Comparator sections.

## Scope / verification
CSS-only (`assets/styles.css`) — **not a vite input**, generated bundles unchanged. Verified computed layout at 375px (column direction, full-width title + actions, 0 overflow). 8 e2e green (Node 20).

## Deliberately out of scope
- **3-lane simulator internals** (the comparator/playground rendered components) — their CSS lives in the generated bundles (`ui-shell.css` / `ui-changefeed-playground.css`), so responsive work there is bundle-touching; it's a separate follow-up. They don't break the page (0 overflow) today.
- **Tap-target sizing** — the chips/ghost links are 25–28px, which meet WCAG 2.2 AA's 24px minimum; bumping to 44px is a broader design call affecting desktop, so left for a design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)