### PR TITLE
fix(ux): hero links open rendered letstalkcdc pages, not raw .md downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,21 +98,25 @@
                 <button type="button" class="btn-ghost" id="btnOnboarding">
                   How the playground works
                 </button>
+                <!-- These point at the companion learning site (rendered
+                     pages) rather than raw docs/*.md, which the static deploy
+                     serves as text/markdown (a download, not a readable page).
+                     Concepts live on letstalkcdc per the scope boundary. -->
                 <a
                   class="btn-ghost"
-                  href="docs/change-feed-evaluation-checklist.md"
+                  href="https://sandgraal.github.io/letstalkcdc/intro/"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                 >
-                  Open evaluation checklist
+                  Learn CDC methods ↗
                 </a>
                 <a
                   class="btn-ghost"
-                  href="docs/cdc-method-cheatsheet.md"
+                  href="https://sandgraal.github.io/letstalkcdc/tooling/"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                 >
-                  Open method cheat sheet
+                  Compare CDC tooling ↗
                 </a>
               </div>
               <p class="hero-pathways-tip">

--- a/index.html
+++ b/index.html
@@ -107,16 +107,18 @@
                   href="https://sandgraal.github.io/letstalkcdc/intro/"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Learn CDC methods on Let’s Talk CDC (opens in a new tab)"
                 >
-                  Learn CDC methods ↗
+                  Learn CDC methods <span aria-hidden="true">↗</span>
                 </a>
                 <a
                   class="btn-ghost"
                   href="https://sandgraal.github.io/letstalkcdc/tooling/"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Compare CDC tooling on Let’s Talk CDC (opens in a new tab)"
                 >
-                  Compare CDC tooling ↗
+                  Compare CDC tooling <span aria-hidden="true">↗</span>
                 </a>
               </div>
               <p class="hero-pathways-tip">


### PR DESCRIPTION
## Deployed-site bug
The hero's two quick links — "Open evaluation checklist" and "Open method cheat sheet" — pointed at `docs/*.md`. On the **deployed static site** those are served as `text/markdown`, which browsers **download** rather than render. Verified on the live Appwrite deploy:

```
docs/cdc-method-cheatsheet.md          → HTTP 200  content-type: text/markdown
docs/change-feed-evaluation-checklist.md → HTTP 200  content-type: text/markdown
```

So a learner clicking them gets a raw-markdown download, not a readable page.

## Fix
Repoint both to the matching **rendered** pages on the companion education site (each verified live — HTTP 200, `text/html`), consistent with the §0 boundary that concepts live on `letstalkcdc`:

| Hero link | → |
| --- | --- |
| Learn CDC methods ↗ | `https://sandgraal.github.io/letstalkcdc/intro/` |
| Compare CDC tooling ↗ | `https://sandgraal.github.io/letstalkcdc/tooling/` |

The repo's own `cdc-method-cheatsheet.md` / `change-feed-evaluation-checklist.md` are **not orphaned** — they remain linked from `README.md` and `docs/README.md`. Also adds `rel="noopener noreferrer"`.

## Scope / verification
`index.html` only — no bundle impact. Verified the rendered hrefs/labels in-browser and that the target pages resolve live. 9 e2e green.

> Alternative if you'd rather keep the repo's own docs as the target: link to their GitHub-rendered blob URLs instead. I went with `letstalkcdc` to match the established wayfinding pattern — easy to switch if you prefer otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)