### PR TITLE
fix(appwrite): repair realtime + persistence (SDK v13 API + nyc region)

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4187,7 +4187,8 @@ async function initAppwrite() {
   catch { try { await account.createAnonymousSession(); } catch (e) { console.warn("Anonymous session unavailable", e.message); } }
 
   const channel = cfg.channel(cfg.databaseId, cfg.collectionId);
-  const unsubscribe = client.subscribe(channel, (msg) => {
+  // SDK v13 accepts a string or string[]; use the canonical array form.
+  const unsubscribe = client.subscribe([channel], (msg) => {
     const ev = (msg.events && msg.events[0]) || "";
     // Only react to document create events
     if (!ev.includes(".documents.*.create")) return;

--- a/assets/app.js
+++ b/assets/app.js
@@ -4177,14 +4177,17 @@ async function initAppwrite() {
   const client    = new Appwrite.Client().setEndpoint(cfg.endpoint).setProject(cfg.projectId);
   const account   = new Appwrite.Account(client);
   const databases = new Appwrite.Databases(client);
-  const realtime  = new Appwrite.Realtime(client);
+  // Appwrite SDK v13 removed the `Appwrite.Realtime` constructor; realtime is
+  // now `client.subscribe(channel, cb)` directly on the Client. The old
+  // `new Appwrite.Realtime(client)` threw "is not a constructor", which aborted
+  // initAppwrite entirely and silently disabled share links + persistence.
 
   // Try to ensure a session (optional; public perms will still work without it)
   try { await account.get(); }
   catch { try { await account.createAnonymousSession(); } catch (e) { console.warn("Anonymous session unavailable", e.message); } }
 
   const channel = cfg.channel(cfg.databaseId, cfg.collectionId);
-  realtime.subscribe(channel, (msg) => {
+  const unsubscribe = client.subscribe(channel, (msg) => {
     const ev = (msg.events && msg.events[0]) || "";
     // Only react to document create events
     if (!ev.includes(".documents.*.create")) return;
@@ -4209,7 +4212,7 @@ async function initAppwrite() {
     }
   });
 
-  appwrite = { client, account, databases, realtime, cfg };
+  appwrite = { client, account, databases, unsubscribe, cfg };
 }
 
 function safeParse(s) { try { return JSON.parse(s); } catch { return s; } }

--- a/index.html
+++ b/index.html
@@ -642,7 +642,11 @@
     <script src="https://cdn.jsdelivr.net/npm/appwrite@13.0.0"></script>
     <script>
       window.APPWRITE_CFG = {
-        endpoint: "https://cloud.appwrite.io/v1",
+        // Regional endpoint: this project lives in Appwrite Cloud's `nyc`
+        // region. The generic https://cloud.appwrite.io/v1 returns
+        // "Project is not accessible in this region", which broke realtime +
+        // scenario persistence + share links.
+        endpoint: "https://nyc.cloud.appwrite.io/v1",
         projectId: "68e009780030a983a57d",
         databaseId: "68e028d90039fa4588f5",
         collectionId: "events",


### PR DESCRIPTION
Found by driving the app like a learner: clicking **Copy Share Link** did nothing, and the console showed `Appwrite.Realtime is not a constructor`. The Appwrite integration was fully broken — taking share links, scenario persistence, and realtime sync with it. Two independent bugs:

## 1. SDK v13 API change (`assets/app.js`)
`new Appwrite.Realtime(client)` throws *"is not a constructor"* in Appwrite SDK v13 (loaded from the CDN). That aborted `initAppwrite()` before `appwrite` was set, so every share/save silently hit the *"Connect to Appwrite"* guard. Migrated to the v13 API: `client.subscribe(channel, cb)`.

## 2. Wrong region endpoint (`index.html`)
The project is in Appwrite Cloud's **nyc** region, but the config used the generic `https://cloud.appwrite.io/v1`. Evidence:

```
cloud.appwrite.io/v1     → 401 "Project is not accessible in this region"
nyc.cloud.appwrite.io/v1 → 401 "missing scopes"   (reachable; normal auth response)
```

The generic endpoint also sent realtime into an **infinite reconnect-error loop**. Switched to `https://nyc.cloud.appwrite.io/v1`.

## Verified in-browser (before → after)
- ❌ `Appwrite.Realtime is not a constructor` → ✅ gone
- ❌ `Project is not accessible in this region` → ✅ gone
- ❌ `Realtime got disconnected. Reconnect will be attempted…` (looping) → ✅ gone
- ✅ Anonymous session establishes; realtime subscribes; only a benign localStorage security advisory remains; **zero error-level logs**.

## Out of scope (server-side — needs the Appwrite console)
Guest document writes still return *"Cloud save failed"* — that's the collection's **create permissions**, not client code. These two fixes are the prerequisite for save/share to even be attempted; granting guest/user create perms on the `events`/`scenarios` collections is the remaining step, and it's yours to configure.

## Scope
`assets/app.js` + `index.html` only (not vite inputs) — generated bundles unchanged. 9 e2e green (Node 20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)