### PR TITLE
docs(appwrite): exact setup for realtime/persistence/share + scenarios caveat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Documentation for the **interactive CDC simulator** (CDC Method Comparator + Cha
 ## Using the simulator (tool-scoped)
 - [comparator-guide.md](comparator-guide.md) — launch, navigate, and demo the React comparator shell.
 - [configuration-guide.md](configuration-guide.md) — run-mode matrix, feature-flag sources, Appwrite setup.
+- [appwrite-setup.md](appwrite-setup.md) — exact collections, attributes, and permissions for realtime + persistence + share links.
 - [feature-flags.md](feature-flags.md) — flag catalogue and defaults.
 - [canonical-scenario.md](canonical-scenario.md) — the failure-aware Docker reference pipeline (what should/does happen, recovery).
 

--- a/docs/appwrite-setup.md
+++ b/docs/appwrite-setup.md
@@ -26,11 +26,11 @@ This guide is the exact, code-grounded setup needed to make those work. It compl
 
 ## 2. Sessions & permissions model
 
-On load the app calls `account.get()`, then `account.createAnonymousSession()` if there's no session (`assets/app.js → initAppwrite`). So **visitors act as either an anonymous user or a logged-in user — never a true API key**. Collection permissions must therefore grant the relevant role:
+On load the app calls `account.get()`, then *attempts* `account.createAnonymousSession()` if there's no session (`assets/app.js → initAppwrite`). That attempt is **best-effort** — if it fails the code logs a warning and continues as an unauthenticated guest. So requests run as a guest, an anonymous user, or a logged-in user — never a true API key. Set collection permissions for the role you actually rely on:
 
-- To let any visitor write/read: grant **Create** and **Read** to `Any` (or `Users` if you require login).
+- To let any visitor write/read **without login**: grant **Create** and **Read** to `Any`. This works for unauthenticated guests, so an anonymous session is **not required** in this mode.
 - For share links to open for *other* people, the `scenarios` collection needs **Read** for `Any`.
-- **Enable Anonymous sessions**: Appwrite Console → Auth → Settings → enable "Anonymous". Without it, `createAnonymousSession()` fails and writes are rejected.
+- **Anonymous sessions are optional** — enable them (Appwrite Console → Auth → Settings → "Anonymous") only if you scope permissions to `Users` instead of `Any`, or want a distinct per-visitor identity. With `Any` permissions, leaving them off is fine.
 
 > ⚠️ **Security trade-off:** `Create` for `Any` means anyone can write documents. For a public demo that's usually fine, but consider Appwrite's rate limits / abuse protection, or scope to `Users` with a login.
 
@@ -43,7 +43,7 @@ On load the app calls `account.get()`, then `account.createAnonymousSession()` i
 | Attribute | Type | Size | Required | Notes |
 | --- | --- | --- | --- | --- |
 | `ts_ms` | integer | — | yes | `Date.now()` at write time |
-| `op` | string | 16 | yes | op code (`c`/`r`/`u`/`d` or `insert`/`update`/`delete`) |
+| `op` | string | 16 | yes | Debezium-style op code — `publishEvent()` always writes one of `c` (create), `r` (read/snapshot), `u` (update), `d` (delete) |
 | `before` | string | 1,000,000 | no | row image before, JSON-stringified; nullable |
 | `after` | string | 1,000,000 | no | row image after, JSON-stringified; nullable |
 

--- a/docs/appwrite-setup.md
+++ b/docs/appwrite-setup.md
@@ -1,0 +1,150 @@
+# Appwrite Setup (realtime, persistence & share links)
+
+The playground runs fully offline by default. The optional **Appwrite** integration adds three things:
+
+1. **Realtime** — change events written by one client appear live in others.
+2. **Scenario persistence** — "Save scenario" stores a snapshot in Appwrite.
+3. **Share links** — "Copy Share Link" returns a `?scenario=<id>` URL that reloads that snapshot.
+
+This guide is the exact, code-grounded setup needed to make those work. It complements the short "Appwrite configuration surface" in [`configuration-guide.md`](configuration-guide.md).
+
+> **Status (2026-06):** the client-side integration was repaired in #285 (SDK v13 `client.subscribe`, and the **regional** `nyc` endpoint). With that, the client connects and an anonymous session is established. What remains is **server-side**: creating the collections/attributes and granting permissions below. One collection (`scenarios`) also needs a small code change — see [§ Scenario persistence caveat](#scenario-persistence-caveat).
+
+---
+
+## 1. Project & endpoint
+
+`window.APPWRITE_CFG` in [`index.html`](../index.html) drives everything:
+
+| Field | Current value | Notes |
+| --- | --- | --- |
+| `endpoint` | `https://nyc.cloud.appwrite.io/v1` | **Must be the project's regional endpoint.** The generic `cloud.appwrite.io/v1` returns *"Project is not accessible in this region"* and loops realtime reconnects. This project lives in `nyc`. |
+| `projectId` | `68e009780030a983a57d` | |
+| `databaseId` | `68e028d90039fa4588f5` | The database holding both collections below. |
+| `collectionId` | `events` | Change-event stream (realtime + persistence). |
+| `scenarioCollectionId` | `scenarios` | Saved scenario snapshots (save + share). |
+
+## 2. Sessions & permissions model
+
+On load the app calls `account.get()`, then `account.createAnonymousSession()` if there's no session (`assets/app.js → initAppwrite`). So **visitors act as either an anonymous user or a logged-in user — never a true API key**. Collection permissions must therefore grant the relevant role:
+
+- To let any visitor write/read: grant **Create** and **Read** to `Any` (or `Users` if you require login).
+- For share links to open for *other* people, the `scenarios` collection needs **Read** for `Any`.
+- **Enable Anonymous sessions**: Appwrite Console → Auth → Settings → enable "Anonymous". Without it, `createAnonymousSession()` fails and writes are rejected.
+
+> ⚠️ **Security trade-off:** `Create` for `Any` means anyone can write documents. For a public demo that's usually fine, but consider Appwrite's rate limits / abuse protection, or scope to `Users` with a login.
+
+---
+
+## 3. Collection: `events` ✅ (config-only — works with current code)
+
+`publishEvent()` writes one document per change op. It first tries native JSON, then falls back to JSON-**stringified** `before`/`after` if the attributes are strings — so define them as strings.
+
+| Attribute | Type | Size | Required | Notes |
+| --- | --- | --- | --- | --- |
+| `ts_ms` | integer | — | yes | `Date.now()` at write time |
+| `op` | string | 16 | yes | op code (`c`/`r`/`u`/`d` or `insert`/`update`/`delete`) |
+| `before` | string | 1,000,000 | no | row image before, JSON-stringified; nullable |
+| `after` | string | 1,000,000 | no | row image after, JSON-stringified; nullable |
+
+- **Permissions:** Create + Read (per § 2).
+- **Realtime:** no extra config — `client.subscribe('databases.<db>.collections.events.documents', …)` receives `*.create` events automatically once the collection exists and Read is granted.
+
+With this collection in place, realtime + event persistence work against the current code.
+
+---
+
+## 4. Collection: `scenarios` ⚠️ (needs a small code change too)
+
+`saveScenarioRemote()` writes this snapshot, and the share-load path reads it back:
+
+| Field | Type in code | Appwrite-storable as-is? |
+| --- | --- | --- |
+| `kind` | string (`"scenario"`) | ✅ string |
+| `version` | integer (`2`) | ✅ integer |
+| `saved_at` | ISO string | ✅ string/datetime |
+| `scenarioId` | string \| null | ✅ string (optional) |
+| `officeOptIn` | boolean | ✅ boolean |
+| `schema` | **array of objects** | ❌ no native type |
+| `rows` | **array of objects** | ❌ no native type |
+| `events` | **array of objects** | ❌ no native type |
+| `comparator` | **object** | ❌ no native type |
+
+<a id="scenario-persistence-caveat"></a>
+
+### Scenario persistence caveat
+
+Appwrite attributes are typed scalars (or arrays of scalars) — there is **no nested-object/JSON attribute type**. The current code writes `schema`/`rows`/`events`/`comparator` as raw nested objects (`databases.createDocument(..., snapshot)`) and the load path reads them back as raw objects (`doc.schema || []`). Appwrite will reject the raw nested write, which is why "Save scenario" currently surfaces *"Cloud save failed. Check Appwrite configuration."* even after the client connects.
+
+**Two ways to resolve (pick one):**
+
+**Option A — one payload string (smallest change).** Add a single large string attribute and (de)serialize the whole snapshot:
+- Attribute: `payload` — string, size `1,000,000`, required.
+- Code: in `saveScenarioRemote`, send `{ kind, version, saved_at, scenarioId, payload: JSON.stringify({schema, rows, events, comparator, officeOptIn}) }`; in the share-load path (`assets/app.js` ~L1920) and `importScenario`, `JSON.parse(doc.payload)` before assigning to `state`.
+
+**Option B — per-field string attributes.** Define `schema`, `rows`, `events`, `comparator` as string attributes (size `1,000,000`) and `JSON.stringify` each on save / `JSON.parse` each on load. More columns, but individual fields stay queryable.
+
+Recommended attributes for **Option A**:
+
+| Attribute | Type | Size | Required |
+| --- | --- | --- | --- |
+| `kind` | string | 32 | yes |
+| `version` | integer | — | yes |
+| `saved_at` | string | 40 | no |
+| `scenarioId` | string | 128 | no |
+| `payload` | string | 1,000,000 | yes |
+
+- **Permissions:** Create + Read for `Any` (Read for `Any` is what makes a shared link open for other people).
+
+Until Option A or B lands, **event persistence/realtime (collection `events`) works, but scenario save/share does not.** Track this in [`issues/appwrite-persistence.md`](issues/appwrite-persistence.md).
+
+---
+
+## 5. Quick verification
+
+After creating the collections + permissions:
+
+1. Load the deployed site; open the console. You should see **no** "not accessible in this region" / "not a constructor" / reconnect-loop errors (only a benign localStorage advisory).
+2. Fire a few operations in the workspace → documents should appear in the `events` collection (Appwrite Console → Databases → events).
+3. Open the same page in a second browser → those events should stream in live (realtime).
+4. (After the §4 code change) "Save scenario" → "Copy Share Link" → open the link in a fresh browser → the scenario reloads.
+
+## 6. CLI reference (`appwrite.json`)
+
+A starting point for the Appwrite CLI (`appwrite push collections`). Adjust to your CLI version — the markdown tables above are authoritative.
+
+```jsonc
+{
+  "projectId": "68e009780030a983a57d",
+  "databases": [{ "$id": "68e028d90039fa4588f5", "name": "playground" }],
+  "collections": [
+    {
+      "$id": "events",
+      "databaseId": "68e028d90039fa4588f5",
+      "name": "events",
+      "documentSecurity": false,
+      "$permissions": ["create(\"any\")", "read(\"any\")"],
+      "attributes": [
+        { "key": "ts_ms",  "type": "integer", "required": true },
+        { "key": "op",     "type": "string",  "size": 16, "required": true },
+        { "key": "before", "type": "string",  "size": 1000000, "required": false },
+        { "key": "after",  "type": "string",  "size": 1000000, "required": false }
+      ]
+    },
+    {
+      "$id": "scenarios",
+      "databaseId": "68e028d90039fa4588f5",
+      "name": "scenarios",
+      "documentSecurity": false,
+      "$permissions": ["create(\"any\")", "read(\"any\")"],
+      "attributes": [
+        { "key": "kind",       "type": "string",  "size": 32,  "required": true },
+        { "key": "version",    "type": "integer", "required": true },
+        { "key": "saved_at",   "type": "string",  "size": 40,  "required": false },
+        { "key": "scenarioId", "type": "string",  "size": 128, "required": false },
+        { "key": "payload",    "type": "string",  "size": 1000000, "required": true }
+      ]
+    }
+  ]
+}
+```

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -35,9 +35,12 @@ Use the **Copy** button in that card to grab a JSON payload that can seed guided
 
 ## Appwrite configuration surface
 
+> For the **exact** collections, attributes, and permissions needed to make realtime, scenario persistence, and share links work — plus the known `scenarios` serialization caveat — see **[`appwrite-setup.md`](appwrite-setup.md)**. This section is just the config-object overview.
+
 `index.html` seeds an `APPWRITE_CFG` object that you can override for your own stack:
 
-- **endpoint / projectId / databaseId / collectionId / scenarioCollectionId** – Used by the workspace exporter/importer; keep demo data isolated per project.
+- **endpoint** – Must be the project's **regional** endpoint (e.g. `https://nyc.cloud.appwrite.io/v1`); the generic `https://cloud.appwrite.io/v1` returns "Project is not accessible in this region" and breaks realtime.
+- **projectId / databaseId / collectionId / scenarioCollectionId** – Used by the workspace exporter/importer; keep demo data isolated per project.
 - **shareBaseUrl** – Host name used when generating share links.
 - **channel(db, col)** – Helper to build realtime subscription topics.
 - **assetHeaders** – Optional map of headers (e.g., `X-Appwrite-Project`) sent when fetching hosted bundles like `assets/generated/ui-shell.js`.

--- a/docs/issues/appwrite-persistence.md
+++ b/docs/issues/appwrite-persistence.md
@@ -1,5 +1,7 @@
 # Issue: Appwrite-backed persistence for scenarios and telemetry
 
+> **Update (2026-06):** the client integration is repaired (#285) and the required collections/attributes/permissions are now documented in [`../appwrite-setup.md`](../appwrite-setup.md). That covers the "document required schemas" item; the open work is the `scenarios` serialization change (Option A/B in that doc) so snapshots persist, plus configuring the collections in the Appwrite console.
+
 ## Summary
 Implement persistent storage powered by Appwrite so that simulator scenarios, configuration, and comparator telemetry survive page reloads and can be shared across sessions.
 


### PR DESCRIPTION
Follow-up to #285 (which repaired the **client** Appwrite integration). This documents exactly what the **server** side needs so realtime, scenario persistence, and share links work end-to-end — all derived from the code (`publishEvent`, `saveScenarioRemote`, the share-load path), not guessed.

## New: `docs/appwrite-setup.md`
- **Regional endpoint** requirement (`nyc.cloud.appwrite.io/v1`) and why the generic endpoint fails.
- **Session/permission model**: visitors use anonymous sessions, so collection perms must grant Create/Read to the role; Anonymous auth must be enabled.
- **`events` collection** — `ts_ms` / `op` / `before` / `after` attributes. **Config-only**: works with the current code (it already falls back to JSON-stringified strings). This makes realtime + event persistence work.
- **`scenarios` collection** — documents the real blocker: the snapshot's nested objects (`schema`/`rows`/`events`/`comparator`) have **no native Appwrite attribute type**, and the code writes/reads them raw. That's why "Cloud save failed" persists even after #285. Two concrete fixes given (Option A: single `payload` string + (de)serialize; Option B: per-field strings).
- Verification steps + an `appwrite.json` CLI reference.

## Honest scope
This is the documentation you picked — it does **not** itself make scenario save work (that needs the small §4 code change + you creating the collections/permissions in your Appwrite console). The `events` collection, however, is fully actionable from config alone. Cross-linked from `docs/README.md` and `configuration-guide.md`; updated the `appwrite-persistence` tracking issue.

Docs only — no code/bundle impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)