### PR TITLE
feat(appwrite): persist scenarios as a flat payload string (Option A)

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1933,8 +1933,20 @@ async function maybeHydrateSharedScenario() {
     }
 
     // v2 packs the snapshot into a single `payload` string; older docs (if
-    // any) used top-level fields. Prefer payload, fall back to the doc itself.
-    const data = typeof doc.payload === "string" ? (safeParse(doc.payload) || {}) : doc;
+    // any) used top-level fields. Parse strictly: if a `payload` is present but
+    // not a valid object, abort rather than overwrite the current workspace
+    // with empties (safeParse returns the raw string on failure, so guard the
+    // type explicitly).
+    let data = doc;
+    if (typeof doc.payload === "string") {
+      let parsed;
+      try { parsed = JSON.parse(doc.payload); } catch { parsed = null; }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        refreshSchemaStatus("Shared scenario could not be read (corrupt payload).", "error");
+        return;
+      }
+      data = parsed;
+    }
 
     const officePref =
       typeof data.officeOptIn === "boolean"

--- a/assets/app.js
+++ b/assets/app.js
@@ -1806,16 +1806,25 @@ async function saveScenarioRemote(options = {}) {
     return null;
   }
 
+  // Appwrite attributes are typed scalars — there is no nested-object/JSON
+  // type. Pack the nested snapshot (schema/rows/events/comparator) into a
+  // single `payload` string so it round-trips through a plain string
+  // attribute. See docs/appwrite-setup.md § "scenarios". The reader
+  // (maybeHydrateSharedScenario) unpacks `payload`, with a fallback to the
+  // legacy top-level fields.
   const snapshot = {
     kind: "scenario",
     version: 2,
     saved_at: new Date().toISOString(),
-    schema: clone(state.schema),
-    rows: clone(state.rows),
-    events: clone(state.events),
-    scenarioId: state.scenarioId,
-    comparator: buildComparatorExport(),
-    officeOptIn: officeSchemaOptIn,
+    scenarioId: state.scenarioId || null,
+    payload: JSON.stringify({
+      schema: clone(state.schema),
+      rows: clone(state.rows),
+      events: clone(state.events),
+      comparator: buildComparatorExport(),
+      officeOptIn: officeSchemaOptIn,
+      schemaVersion: state.schemaVersion,
+    }),
   };
 
   const reuseId = state.remoteId || uiState.lastShareId;
@@ -1923,31 +1932,38 @@ async function maybeHydrateSharedScenario() {
       return;
     }
 
+    // v2 packs the snapshot into a single `payload` string; older docs (if
+    // any) used top-level fields. Prefer payload, fall back to the doc itself.
+    const data = typeof doc.payload === "string" ? (safeParse(doc.payload) || {}) : doc;
+
     const officePref =
-      typeof doc.officeOptIn === "boolean"
-        ? doc.officeOptIn
-        : typeof doc.officeSchemaOptIn === "boolean"
-          ? doc.officeSchemaOptIn
-          : null;
+      typeof data.officeOptIn === "boolean"
+        ? data.officeOptIn
+        : typeof doc.officeOptIn === "boolean"
+          ? doc.officeOptIn
+          : typeof doc.officeSchemaOptIn === "boolean"
+            ? doc.officeSchemaOptIn
+            : null;
     if (officePref !== null) {
       setOfficeSchemaPreference(officePref);
     }
 
-    state.schema = doc.schema || [];
-    state.schemaVersion = Number(doc.schemaVersion) || 1;
-    state.rows = doc.rows || [];
-    state.events = doc.events || [];
-    state.scenarioId = doc.scenarioId || null;
+    const comparator = data.comparator || doc.comparator;
+    state.schema = data.schema || [];
+    state.schemaVersion = Number(data.schemaVersion ?? doc.schemaVersion) || 1;
+    state.rows = data.rows || [];
+    state.events = data.events || [];
+    state.scenarioId = doc.scenarioId || data.scenarioId || null;
     state.remoteId = doc.$id;
 
     if (state.events.length) selectLastEvent(); else resetEventSelection();
     if (state.scenarioId) storage.set(STORAGE_KEYS.lastTemplate, state.scenarioId);
-    if (doc.comparator?.preferences) {
-      applyComparatorPreferences(doc.comparator.preferences);
+    if (comparator?.preferences) {
+      applyComparatorPreferences(comparator.preferences);
     }
-    const sharedDetail = buildComparatorSnapshotDetail(doc.comparator, {
-      label: doc.scenarioId || "Shared scenario",
-      name: doc.scenarioId || "shared",
+    const sharedDetail = buildComparatorSnapshotDetail(comparator, {
+      label: state.scenarioId || "Shared scenario",
+      name: state.scenarioId || "shared",
       isLive: false,
       rowsLength: state.rows.length,
       eventsLength: state.events.length,


### PR DESCRIPTION
Implements **Option A** from [`docs/appwrite-setup.md`](https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground/blob/main/docs/appwrite-setup.md) — the remaining code piece so scenario **Save** / **Copy Share Link** actually persist.

## Why
Appwrite attributes are typed scalars — there's no nested-object/JSON type. The old `saveScenarioRemote` snapshot wrote raw `schema`/`rows`/`events`/`comparator` objects, which Appwrite can't store, so saves failed with *"Cloud save failed"* even after the client connection was repaired in #285.

## Change (`assets/app.js`)
- **Save:** flatten to `{ kind, version, saved_at, scenarioId, payload }` where `payload = JSON.stringify({ schema, rows, events, comparator, officeOptIn, schemaVersion })`.
- **Load (`maybeHydrateSharedScenario`):** unpack `payload` (`safeParse`), with a fallback to legacy top-level fields for safety.

This matches the documented `scenarios` schema (the `payload` string attribute). The `events` collection path is unchanged.

## Verification
- In-browser, mocking the Appwrite `Databases` prototype: the captured save snapshot is **flat**, `payload` is a **string**, and it `JSON.parse`s back to the exact `schema` (cols `[id,name,email]`), `rows` (1), and `comparator` — round-trip integrity confirmed. The load path is the direct inverse of that round-trip.
- `9 e2e` green (all specs load `app.js`); generated bundles unchanged (`app.js` is not a vite input).

## Still needs you (server-side)
Per the setup doc: create the `scenarios` collection with the `payload` attribute + Create/Read permissions in the Appwrite console. With that, this code makes save + share links work end-to-end. (The full live round-trip can only be verified against the configured collection.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)