### PR TITLE
fix(onboarding+tour): working orders CTA, Scranton-by-default, robust walkthrough

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -751,7 +751,6 @@ const els = {
   onboardingClose: document.getElementById("onboardingClose"),
   onboardingDismiss: document.getElementById("onboardingDismiss"),
   onboardingStart: document.getElementById("onboardingStart"),
-  onboardingEasterEgg: document.getElementById("onboardingEasterEgg"),
   methodGuidance: document.getElementById("methodGuidance"),
   saveRemote: document.getElementById("btnSaveRemote"),
   shareLink: document.getElementById("btnShareLink"),
@@ -815,9 +814,6 @@ function ensureOnboardingElements() {
   }
   if (!els.onboardingStart) {
     els.onboardingStart = document.getElementById("onboardingStart");
-  }
-  if (!els.onboardingEasterEgg) {
-    els.onboardingEasterEgg = document.getElementById("onboardingEasterEgg");
   }
 }
 
@@ -1645,9 +1641,6 @@ function showOnboarding() {
   if (!els.onboardingOverlay) return;
   els.onboardingOverlay.hidden = false;
   document.body.classList.add("is-onboarding");
-  if (els.onboardingEasterEgg) {
-    els.onboardingEasterEgg.checked = false;
-  }
   const dialog = els.onboardingOverlay.querySelector(".onboarding-dialog");
   if (dialog && typeof dialog.focus === "function") {
     dialog.focus({ preventScroll: true });
@@ -1744,28 +1737,28 @@ function resetWorkspaceState(loadOffice) {
 
 function startFromScratch() {
   ensureOnboardingElements();
-  const loadOffice = Boolean(els.onboardingEasterEgg?.checked);
-  setOfficeSchemaPreference(loadOffice);
-
-  resetWorkspaceState(loadOffice);
-
+  // "Start from scratch" now always loads the Scranton sample schema (the old
+  // opt-in checkbox is gone) so learners land on a real, populated table
+  // instead of a blank "add a column" canvas.
+  setOfficeSchemaPreference(true);
+  resetWorkspaceState(true);
   storage.remove(STORAGE_KEYS.lastTemplate);
-  if (els.onboardingEasterEgg) els.onboardingEasterEgg.checked = false;
 
-  save();
   renderSchema();
   renderEditor();
-  renderTable();
+  // Seed a few sample rows from the schema. seedRows() also saves + renders the
+  // table, and auto-applies Office lore because isOfficeSchemaActive() is true.
+  seedRows();
   renderJSONLog();
   renderTemplateGallery();
   syncSchemaDemoButtons();
 
   refreshSchemaStatus(
-    loadOffice ? "Scranton schema unlocked. Dwight is watching." : "Blank workspace ready. Add a column to begin.",
-    loadOffice ? "success" : "muted"
+    "Scranton schema loaded with sample rows. Stream events or edit the table to begin.",
+    "success"
   );
-  updateLearning("schema");
-  trackEvent("workspace.scenario.start_from_scratch", { officeSchema: loadOffice });
+  updateLearning("events");
+  trackEvent("workspace.scenario.start_from_scratch", { officeSchema: true });
   hideOnboarding(true);
 }
 
@@ -3312,6 +3305,26 @@ function updateTourUi(stepIndex, step, placeholderDescription = "") {
   if (ui.nextBtn) ui.nextBtn.textContent = stepIndex === steps.length - 1 ? "Finish" : "Next";
 }
 
+// Show a transient note in the tour panel body (e.g. when a step is skipped).
+function showTourNote(message) {
+  if (activeTour?.ui?.body) activeTour.ui.body.textContent = message;
+}
+
+// When the comparator is turned off, its steps' targets never appear. Skip the
+// whole comparator block in one move (with a single note) instead of stalling
+// on each step's timeout.
+function skipRemainingComparatorSteps() {
+  if (!activeTour) return;
+  let i = activeTour.index;
+  while (i < activeTour.steps.length && String(activeTour.steps[i].id || "").startsWith("comparator-")) {
+    i += 1;
+    activeTour.skipped += 1;
+  }
+  showTourNote("The comparator isn’t turned on — skipping its steps. Enable it to explore lane metrics.");
+  activeTour.index = i - 1; // handleTourNext() advances to i (or finishes)
+  window.setTimeout(() => { if (activeTour) handleTourNext(); }, 1500);
+}
+
 function showTourStep(stepIndex) {
   if (!activeTour) return;
   const step = activeTour.steps[stepIndex];
@@ -3322,6 +3335,20 @@ function showTourStep(stepIndex) {
 
   updateTourUi(stepIndex, step);
 
+  // Comparator steps target React-rendered elements. If the comparator is off,
+  // skip its steps cleanly; otherwise scroll its region into view so React lays
+  // out before we wait, keeping waitForElement fast instead of timing out.
+  if (typeof step.id === "string" && step.id.startsWith("comparator-")) {
+    if (!isComparatorFlagEnabled()) {
+      skipRemainingComparatorSteps();
+      return;
+    }
+    const preview = document.getElementById("sim-shell-preview");
+    if (preview) {
+      try { preview.scrollIntoView({ behavior: "smooth", block: "start" }); } catch { /* ignore */ }
+    }
+  }
+
   const timeout = typeof step.timeout === "number" ? step.timeout : TOUR_DEFAULT_TIMEOUT;
   const token = Symbol("tour-step");
   activeTour.pendingToken = token;
@@ -3330,7 +3357,12 @@ function showTourStep(stepIndex) {
       if (!activeTour || activeTour.pendingToken !== token) return;
 
       if (!element) {
-        handleTourNext();
+        // Don't silently jump — surface a brief note, then advance.
+        activeTour.skipped += 1;
+        showTourNote(`Skipping “${step.title}” — it isn’t available right now.`);
+        window.setTimeout(() => {
+          if (activeTour && activeTour.pendingToken === token) handleTourNext();
+        }, 1200);
         return;
       }
 
@@ -3405,7 +3437,7 @@ function handleTourKeydown(event) {
 function finishTour(completed, reason) {
   if (!activeTour) return;
   clearTourHighlight();
-  const { ui, startedAt, steps, index, keydownHandler } = activeTour;
+  const { ui, startedAt, steps, index, keydownHandler, skipped = 0 } = activeTour;
 
   if (ui) {
     if (ui.nextBtn) ui.nextBtn.removeEventListener("click", handleTourNext);
@@ -3420,7 +3452,12 @@ function finishTour(completed, reason) {
 
   const durationMs = Date.now() - startedAt;
   if (completed) {
-    trackEvent("tour.completed", { totalSteps: steps.length, durationMs });
+    trackEvent("tour.completed", {
+      totalSteps: steps.length,
+      durationMs,
+      skipped,
+      status: skipped > 0 ? "completed_with_skips" : "completed",
+    });
   } else {
     trackEvent("tour.dismissed", {
       totalSteps: steps.length,
@@ -3460,6 +3497,7 @@ function startGuidedTour() {
     ui,
     pendingToken: null,
     keydownHandler,
+    skipped: 0,
   };
 
   trackEvent("tour.started", {
@@ -4923,7 +4961,7 @@ function bindUiHandlers() {
   }
   if (els.onboardingStart) {
     els.onboardingStart.onclick = () => {
-      const template = getTemplateById("orders");
+      const template = getTemplateById("omnichannel-orders");
       applyScenarioTemplate(template, { focusStep: "rows", closeOnboarding: true });
     };
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -3322,7 +3322,13 @@ function skipRemainingComparatorSteps() {
   }
   showTourNote("The comparator isn’t turned on — skipping its steps. Enable it to explore lane metrics.");
   activeTour.index = i - 1; // handleTourNext() advances to i (or finishes)
-  window.setTimeout(() => { if (activeTour) handleTourNext(); }, 1500);
+  // Claim a fresh pendingToken so a manual Next/Back (or a prior step's
+  // waitForElement resolving) can't double-advance or apply a stale highlight.
+  const token = Symbol("tour-skip");
+  activeTour.pendingToken = token;
+  window.setTimeout(() => {
+    if (activeTour && activeTour.pendingToken === token) handleTourNext();
+  }, 1500);
 }
 
 function showTourStep(stepIndex) {

--- a/index.html
+++ b/index.html
@@ -78,7 +78,11 @@
           <p class="hero-lead hero-lead--secondary">
             This is the hands-on simulator. New to CDC, or want the concepts,
             labs, and vendor guides? Visit
+            <a
+              href="https://sandgraal.github.io/letstalkcdc/"
+              target="_blank"
               rel="noopener noreferrer"
+              >Let’s Talk CDC</a
             >, the companion learning site.
           </p>
         </div>

--- a/index.html
+++ b/index.html
@@ -731,57 +731,10 @@
         }
       })();
     </script>
-    <script>
-      (() => {
-        const DEFAULT_STATUS_TEXT = "Add a column to begin";
-
-        const overlay = document.getElementById("onboardingOverlay");
-        const status = document.getElementById("schemaStatus");
-        const pills = document.getElementById("schemaPills");
-        const start = document.getElementById("onboardingStart");
-
-        const defaultState = {
-          schema: [],
-          rows: [],
-          events: [],
-          schemaVersion: 1,
-          scenarioId: null,
-          remoteId: null,
-        };
-
-        function seedBlankWorkspace() {
-          try {
-            window.localStorage.setItem(
-              "cdc_playground",
-              JSON.stringify(defaultState)
-            );
-            window.localStorage.setItem(
-              "cdc_playground_office_opt_in_v1",
-              "false"
-            );
-          } catch {
-            /* ignore storage errors */
-          }
-          if (status) status.textContent = DEFAULT_STATUS_TEXT;
-          if (pills) pills.replaceChildren();
-          if (overlay) overlay.style.display = "none";
-        }
-
-        start?.addEventListener("click", (event) => {
-          event.preventDefault();
-          seedBlankWorkspace();
-        });
-
-        function initializeOverlay() {
-          if (status && !status.textContent) {
-            status.textContent = DEFAULT_STATUS_TEXT;
-          }
-          if (overlay) overlay.style.display = "";
-        }
-
-        window.seedBlankWorkspace = seedBlankWorkspace;
-      })();
-    </script>
+    <!-- Onboarding is handled in assets/app.js (bindUiHandlers /
+         startFromScratch). A previous inline script also bound #onboardingStart
+         to seed a blank workspace, which conflicted with app.js's handler — it
+         has been removed so app.js is the single source of truth. -->
     <script type="module" src="assets/method-copy.js"></script>
     <script type="module" src="assets/shared-scenarios.js"></script>
     <script src="assets/sim-loader.js"></script>

--- a/index.html
+++ b/index.html
@@ -579,14 +579,6 @@
             <button type="button" id="onboardingDismiss" class="btn-ghost">
               Start from scratch
             </button>
-            <label class="checkbox onboarding-secret" for="onboardingEasterEgg">
-              <input
-                type="checkbox"
-                id="onboardingEasterEgg"
-                autocomplete="off"
-              />
-              <span>Include the Scranton schema (shh)</span>
-            </label>
           </div>
         </div>
       </div>

--- a/tests/e2e/workspace-onboarding.spec.mjs
+++ b/tests/e2e/workspace-onboarding.spec.mjs
@@ -23,11 +23,14 @@ suite("Workspace onboarding", () => {
     });
   });
 
-  test("start from scratch without Scranton seeds a blank schema", async ({ page }) => {
+  test("start from scratch loads the Scranton schema with sample rows", async ({ page }) => {
     await loadWorkspace(page);
 
     const overlay = page.locator("#onboardingOverlay");
     await expect(overlay).toBeVisible({ timeout: 15000 });
+
+    // The old opt-in Scranton checkbox is gone.
+    await expect(page.locator("#onboardingEasterEgg")).toHaveCount(0);
 
     const startButton = page.getByRole("button", { name: "Start from scratch" });
     await expect(startButton).toBeVisible();
@@ -35,18 +38,16 @@ suite("Workspace onboarding", () => {
 
     await expect(overlay).toBeHidden();
 
-    const schemaPills = page.locator("#schemaPills .pill");
-    await expect(schemaPills).toHaveCount(0);
-
-    await expect(page.locator("#schemaStatus")).toContainText("Add a column to begin");
+    // Learners land on the populated 6-column Scranton schema, not a blank canvas.
+    await expect(page.locator("#schemaPills .pill")).toHaveCount(6);
 
     const stored = await page.evaluate(() => window.localStorage.getItem("cdc_playground"));
     expect(stored).toBeTruthy();
     const parsed = stored ? JSON.parse(stored) : null;
-    expect(parsed?.schema ?? []).toHaveLength(0);
-    expect(parsed?.rows ?? []).toHaveLength(0);
+    expect(parsed?.schema ?? []).toHaveLength(6);
+    expect((parsed?.rows ?? []).length).toBeGreaterThan(0);
 
     const officePref = await page.evaluate(() => window.localStorage.getItem("cdc_playground_office_opt_in_v1"));
-    expect(officePref).toBe("false");
+    expect(officePref).toBe("true");
   });
 });


### PR DESCRIPTION
Phase A of the "make the playground useful for learners" work ([plan](https://github.com/sandgraal/Lets-Talk-CDC-Change-Feed-Playground)). Three learner-facing fixes; **no bundle rebuild**.

## 1. The "hang" — dead onboarding CTA
"Load the orders template" called `getTemplateById("orders")`, but no template has id `"orders"` (they're `omnichannel-orders`, `orders-items-transactions`…). So `applyScenarioTemplate(null)` returned at its early guard — nothing loaded and the modal never closed. To a user: click → nothing → "hung." Fixed by pointing at `omnichannel-orders`; now it loads the scenario **and** closes the modal. (Real templates always loaded fine; there was no true freeze.)

## 2. Scranton schema by default
Removed the "Include the Scranton schema (shh)" checkbox. **"Start from scratch" now always loads the 6-column Scranton schema and seeds ~3 sample rows** (reusing `seedRows()`), so learners land on a populated, streamable table instead of a blank "add a column" canvas. Dropped the dead `onboardingEasterEgg` references.

## 3. Guided walkthrough robustness
Previously, the comparator steps (4–8) targeted React elements that might not be mounted/visible → silent ~7s auto-advances (up to ~35s of dead air), and skipped runs were logged as clean `tour.completed`. Now:
- Scroll the comparator into view before its steps so React lays out and `waitForElement` resolves fast.
- If the comparator is turned off, skip its steps in **one** move with a visible note.
- Surface a brief "Skipping …" note when any target is genuinely missing (no silent jumps).
- Track a `skipped` count so telemetry reports `completed_with_skips`, not a clean completion.

## Verification
In-browser: orders CTA loads Omnichannel Orders + closes modal; start-from-scratch → 6-col Scranton schema + 3 rows, checkbox gone; **all 9 tour steps highlight real elements** (workspace + comparator). Updated the onboarding e2e to the new behavior. **11/11 e2e green** (Node 20). `assets/app.js` + `index.html` only — generated bundles unchanged.

> Phase B (separate PR) will make the §5 "When to use which" guidance interactive (clickable method chips that highlight the comparator lanes) — that one is bundle-touching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)