### PR TITLE
refactor(ui): de-clutter the two simulator section intros

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,19 +473,10 @@
               Change Feed Atomicity Playground
             </h2>
             <p class="section-lead">
-              Three-lane view of source rows, change feed partitions, and consumer apply policies. Toggle drift, drop faults,
-              and backlog throttling to see how transactions behave.
-            </p>
-            <p class="section-lead section-lead--muted">
-              Best for understanding <strong>one</strong> change feed end to end. To compare polling, trigger, and
-              log capture side by side, jump to the
+              Drive one change feed end to end — toggle apply-on-commit, drift, and drop faults to see how
+              transactions hold up. To compare polling, trigger, and log side by side, use the
               <a href="#sim-shell-preview">CDC Method Comparator</a> below.
             </p>
-          </div>
-          <div class="section-actions" role="group" aria-label="Playground actions">
-            <span class="section-pill">Apply on commit vs as polled</span>
-            <span class="section-pill">Commit &amp; schema drift</span>
-            <span class="section-pill">Lag &amp; backlog badges</span>
           </div>
         </div>
         <div id="changefeedPlaygroundRoot" class="playground-react-root">
@@ -508,13 +499,9 @@
               Compare CDC Capture Methods (beta)
             </h2>
             <p class="section-lead">
-              Load the CDC Method Comparator to see how polling, trigger, and
-              log-based capture respond as you run the same operations.
-            </p>
-            <p class="section-lead section-lead--muted">
-              Use this after the
-              <a href="#changefeed-playground">playground above</a> when you want to contrast capture
-              <strong>strategies</strong> rather than trace a single feed.
+              Run the same operations through polling, trigger, and log capture at once and watch lag,
+              ordering, and delete capture diverge live. Best right after the
+              <a href="#changefeed-playground">playground above</a>.
             </p>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -473,8 +473,9 @@
               Change Feed Atomicity Playground
             </h2>
             <p class="section-lead">
-              Drive one change feed end to end — toggle apply-on-commit, drift, and drop faults to see how
-              transactions hold up. To compare polling, trigger, and log side by side, use the
+              Drive one change feed end to end — switch the apply policy (apply on commit vs as polled),
+              introduce schema drift, and drop events to watch how transactions hold up. To compare polling,
+              trigger, and log side by side, use the
               <a href="#sim-shell-preview">CDC Method Comparator</a> below.
             </p>
           </div>


### PR DESCRIPTION
Continues the "bottom half is just words" cleanup. The Change Feed Playground and CDC Method Comparator sections each front-loaded **two prose paragraphs** (and three non-functional decorative pills) before the actual widget.

## Changes (`index.html` only)
- **Change Feed Playground**: two leads → one tight sentence that folds in the key controls (apply-on-commit, drift, drop faults) and keeps the cross-link to the comparator. Removed the three decorative `section-pill` labels — the widget itself surfaces those controls/badges.
- **CDC Method Comparator**: two leads → one sentence + the cross-link to the playground.

The interactive "When to use which" method chips (PR #290) stay — that's the *interactive* guidance, not clutter. Net: each section now reads as **eyebrow → title → one lead → the tool**, so the widgets lead and the remaining words earn their place.

## Verification
In-browser: Change Feed section now has 1 lead / 0 pills; both cross-links work; the comparator's interactive chips intact. `index.html` only — **no bundle changes**. 11/11 e2e green.

> Note: the `.section-pill` / `.section-actions` CSS is now unused; left in place to avoid touching the stylesheet, can be pruned in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)