### PR TITLE
feat(onboarding): surface the guided tour from the welcome modal

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -751,6 +751,7 @@ const els = {
   onboardingClose: document.getElementById("onboardingClose"),
   onboardingDismiss: document.getElementById("onboardingDismiss"),
   onboardingStart: document.getElementById("onboardingStart"),
+  onboardingTour: document.getElementById("onboardingTour"),
   methodGuidance: document.getElementById("methodGuidance"),
   saveRemote: document.getElementById("btnSaveRemote"),
   shareLink: document.getElementById("btnShareLink"),
@@ -814,6 +815,9 @@ function ensureOnboardingElements() {
   }
   if (!els.onboardingStart) {
     els.onboardingStart = document.getElementById("onboardingStart");
+  }
+  if (!els.onboardingTour) {
+    els.onboardingTour = document.getElementById("onboardingTour");
   }
 }
 
@@ -4979,6 +4983,16 @@ function bindUiHandlers() {
     els.onboardingStart.onclick = () => {
       const template = getTemplateById("omnichannel-orders");
       applyScenarioTemplate(template, { focusStep: "rows", closeOnboarding: true });
+    };
+  }
+  if (els.onboardingTour) {
+    els.onboardingTour.onclick = () => {
+      // Load real demo content so the tour has lanes/events to spotlight,
+      // close the welcome modal, then launch the guided walkthrough.
+      const template = getTemplateById("omnichannel-orders");
+      if (template) applyScenarioTemplate(template, { focusStep: "events", closeOnboarding: true });
+      else hideOnboarding(true);
+      startGuidedTour();
     };
   }
   if (els.onboardingOverlay) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2840,6 +2840,29 @@ select:focus {
   gap: 6px;
 }
 
+.onboarding-tour-hint {
+  margin: 14px 0 0;
+  font-size: 13px;
+  color: var(--muted, #94a3b8);
+}
+
+.onboarding-tour-link {
+  font: inherit;
+  font-weight: 600;
+  color: #93c5fd;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.onboarding-tour-link:hover,
+.onboarding-tour-link:focus-visible {
+  color: #bfdbfe;
+}
+
 .onboarding-secret {
   display: inline-flex;
   align-items: center;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2856,11 +2856,23 @@ select:focus {
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 2px;
+  /* Neutralize the global <button> chrome (ripple + hover lift) so this
+     link-like control doesn't jump or show a ripple bubble in the modal. */
+  transform: none;
+  box-shadow: none;
+  transition: color 0.15s ease;
+}
+
+.onboarding-tour-link::before {
+  content: none;
 }
 
 .onboarding-tour-link:hover,
+.onboarding-tour-link:active,
 .onboarding-tour-link:focus-visible {
   color: #bfdbfe;
+  transform: none;
+  box-shadow: none;
 }
 
 .onboarding-secret {

--- a/index.html
+++ b/index.html
@@ -573,6 +573,12 @@
             </button>
           </div>
         </div>
+        <p class="onboarding-tour-hint">
+          New to change data capture?
+          <button type="button" id="onboardingTour" class="onboarding-tour-link">
+            Take the 60-second guided tour
+          </button>
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
Makes the playground **self-introducing** — the next learner-experience lever after the four merged fixes.

## Problem
The guided walkthrough is now reliable (#289), but it's only launchable from a hero button that scrolls away as soon as a learner picks a workspace. Many first-timers never discover it.

## Change
Adds a **"Take the 60-second guided tour"** CTA to the welcome modal that every new visitor sees. It's non-intrusive — no auto-popup. Clicking it:
1. Loads the Omnichannel Orders demo (so the tour has real lanes/events to spotlight),
2. Closes the welcome modal,
3. Launches the guided walkthrough.

`index.html` (modal CTA) + `assets/app.js` (handler + element cache) + `assets/styles.css` (link styling). **No bundle changes.**

## Verified
In-browser: the modal shows the CTA; clicking it loads Orders (6 columns), hides the modal, and opens the tour at step 1 ("Model your schema") highlighting `#schema`. 11/11 e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)