### PR TITLE
Deep-link the comparator's method guidance into Let's Talk CDC (W2)

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -966,6 +966,16 @@ const TOUR_COMPARATOR_TIMEOUT = 7000;
 // concepts. This playground is the hands-on tool; it points learners to
 // letstalkcdc for the theory rather than re-teaching it (see AGENT_TEAM_BRIEF §0).
 const LTCDC_BASE = "https://sandgraal.github.io/letstalkcdc/";
+// Concepts the comparator demonstrates, each linked to its letstalkcdc page so
+// learners can jump from "what just happened" to the full theory. Slugs verified
+// against the letstalkcdc site; keep this list to concepts actually shown here.
+const CONCEPT_DEEP_LINKS = [
+  { label: "How polling, trigger & log differ", href: `${LTCDC_BASE}intro/` },
+  { label: "Replication lag & observability", href: `${LTCDC_BASE}observability/` },
+  { label: "Ordering & partitioning", href: `${LTCDC_BASE}partitioning/` },
+  { label: "Schema evolution", href: `${LTCDC_BASE}schema-evolution/` },
+  { label: "The change-event envelope", href: `${LTCDC_BASE}event-envelope/` },
+];
 const GUIDED_TOUR_STEPS = [
   {
     id: "workspace-schema",
@@ -1151,6 +1161,32 @@ function renderMethodGuidance() {
   });
 
   fragment.appendChild(list);
+
+  // Deep links out to the companion education site for the concepts this
+  // comparator demonstrates — the playground stays the hands-on tool and defers
+  // the theory to letstalkcdc (see AGENT_TEAM_BRIEF §0 / W2). Link, don't re-teach.
+  const deeper = document.createElement("div");
+  deeper.className = "method-guidance__deeper";
+  const deeperHeading = document.createElement("h4");
+  deeperHeading.className = "method-guidance__deeper-heading";
+  deeperHeading.textContent = "Go deeper on Let’s Talk CDC";
+  deeper.appendChild(deeperHeading);
+
+  const deeperList = document.createElement("ul");
+  deeperList.className = "method-guidance__deeper-list";
+  CONCEPT_DEEP_LINKS.forEach(({ label, href }) => {
+    const li = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = href;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = `${label} →`;
+    li.appendChild(link);
+    deeperList.appendChild(li);
+  });
+  deeper.appendChild(deeperList);
+  fragment.appendChild(deeper);
+
   container.innerHTML = "";
   container.appendChild(fragment);
 }

--- a/assets/app.js
+++ b/assets/app.js
@@ -1181,6 +1181,7 @@ function renderMethodGuidance() {
     link.target = "_blank";
     link.rel = "noopener noreferrer";
     link.textContent = `${label} →`;
+    link.setAttribute("aria-label", `${label} on Let’s Talk CDC (opens in a new tab)`);
     li.appendChild(link);
     deeperList.appendChild(li);
   });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3761,6 +3761,45 @@ body[data-theme="light"] .method-guidance__chip {
   font-size: 0.95rem;
 }
 
+/* Outbound "go deeper" links into the letstalkcdc education site. */
+.method-guidance__deeper {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(59, 120, 201, 0.3);
+}
+
+.method-guidance__deeper-heading {
+  margin: 0 0 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: #93c5fd;
+}
+
+.method-guidance__deeper-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
+.method-guidance__deeper-list a {
+  color: #dbeafe;
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(147, 197, 253, 0.45);
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.method-guidance__deeper-list a:hover,
+.method-guidance__deeper-list a:focus-visible {
+  color: #ffffff;
+  border-color: rgba(147, 197, 253, 0.9);
+}
+
 @media (max-width: 1024px) {
   .hero {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What & why

Roadmap item **W2 — wayfinding / cross-link contract**. The comparator's "When to use which" guidance let learners spotlight a lane, but gave them no path to the *theory*. This adds a **"Go deeper on Let's Talk CDC"** links row beneath it, pointing at the concepts the comparator actually demonstrates:

- How polling, trigger & log differ → `intro/`
- Replication lag & observability → `observability/`
- Ordering & partitioning → `partitioning/`
- Schema evolution → `schema-evolution/`
- The change-event envelope → `event-envelope/`

This keeps the playground in its lane (AGENT_TEAM_BRIEF §0): the hands-on tool links *out* for concepts instead of re-teaching them, advancing the two-repo cross-link contract with `letstalkcdc`.

## Notes
- Slugs verified against the actual `letstalkcdc` build (`_site/`); links open in a new tab with `rel="noopener noreferrer"`.
- The `.method-guidance` panel is intentionally dark in both themes, so the links stay light-blue throughout (verified).
- **No bundle rebuild** — `assets/app.js` and `assets/styles.css` load directly.

## Verification
- Links render with correct hrefs in both light/dark; wrap with no overflow at 375px.
- e2e **11/11** green.

> As before, I can't screenshot here — verified via DOM/computed-style checks; worth a glance on the Appwrite preview.