### PR TITLE
fix(tour): stop the guided walkthrough hiding/scrolling its spotlight off-screen

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -3313,10 +3313,6 @@ function waitForElement(selector, timeout = TOUR_DEFAULT_TIMEOUT) {
 }
 
 function createTourUi() {
-  const scrim = document.createElement("div");
-  scrim.className = "tour-scrim";
-  scrim.setAttribute("aria-hidden", "true");
-
   const panel = document.createElement("div");
   panel.className = "tour-panel";
   panel.setAttribute("role", "dialog");
@@ -3338,7 +3334,6 @@ function createTourUi() {
   `;
 
   return {
-    scrim,
     panel,
     stepLabel: panel.querySelector(".tour-panel__step"),
     title: panel.querySelector(".tour-panel__title"),
@@ -3432,7 +3427,7 @@ function showTourStep(stepIndex) {
     activateSimulatorTab("compare");
     const preview = document.getElementById("simulator");
     if (preview) {
-      try { preview.scrollIntoView({ behavior: "smooth", block: "start" }); } catch { /* ignore */ }
+      try { preview.scrollIntoView({ block: "start" }); } catch { /* ignore */ }
     }
   }
 
@@ -3459,7 +3454,10 @@ function showTourStep(stepIndex) {
       activeTour.highlightEl = element;
 
       try {
-        element.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
+        // Instant (not smooth): the workspace streams events continuously, and a
+        // smooth scroll gets interrupted by the layout shifts, leaving the
+        // spotlighted element off-screen. Jump straight to it.
+        element.scrollIntoView({ block: "center", inline: "center" });
       } catch {
         /* ignore */
       }
@@ -3564,7 +3562,6 @@ function stopGuidedTour(reason = "manual") {
 function startGuidedTour() {
   if (activeTour) return;
   const ui = createTourUi();
-  document.body.appendChild(ui.scrim);
   document.body.appendChild(ui.panel);
   document.body.classList.add("tour-active");
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3465,15 +3465,10 @@ body.megadesk-mode .hero-ambient .orb {
   opacity: 0.25;
 }
 
-.tour-scrim {
-  position: fixed;
-  inset: 0;
-  background: rgba(12, 12, 27, 0.45);
-  backdrop-filter: blur(1.5px);
-  z-index: 9000;
-  pointer-events: none;
-}
-
+/* No full-screen dim scrim: the page's backdrop-filter cards create stacking
+   contexts that trap a highlighted child below a root-level scrim (it would
+   render *behind* the dim). The element-attached outline + elevation below is
+   the spotlight instead — it tracks the element as the workspace streams. */
 .tour-panel {
   position: fixed;
   bottom: 32px;
@@ -3561,10 +3556,12 @@ body.megadesk-mode .hero-ambient .orb {
 .tour-highlight {
   position: relative;
   z-index: 9100;
-  outline: 3px solid rgba(99, 102, 241, 0.9);
+  outline: 3px solid rgba(99, 102, 241, 0.95);
   outline-offset: 4px;
   border-radius: 12px;
-  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.2);
+  /* Glow + elevation so the spotlighted element reads as focused without a
+     full-screen dim (which the page's stacking contexts would trap it under). */
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.28), 0 18px 44px -12px rgba(8, 14, 30, 0.6);
   transition: outline-color 0.2s ease, box-shadow 0.2s ease;
 }
 


### PR DESCRIPTION
## What & why

You reported the guided walkthrough "from step 4 looks like this where it is behind" (screenshot: the spotlighted *Schema walkthrough* card sitting under the dim / off-screen). Reproduced and found **two** root causes — both pre-existing, both make the tour feel broken:

### 1. The spotlight scrolled off-screen
Steps used `scrollIntoView({ behavior: "smooth" })`. The workspace streams CDC events continuously, and those layout shifts interrupt the smooth-scroll animation — so the target ended up ~3000px below the fold (measured `top: 3181` in a 680px viewport). An **instant** scroll lands reliably (`top: 276`, in view).

### 2. The spotlight rendered *behind* the dim
`.tour-scrim` is a fixed full-screen dim at `z-index: 9000`; `.tour-highlight` tried to rise above it with `z-index: 9100`. But the page's cards use `backdrop-filter`, which **creates a stacking context** — trapping the highlight's z-index *inside* the card, below the root-level scrim. So the highlighted element was dimmed by the very overlay meant to spotlight it. Confirmed the trapping ancestor (`section.card` with `backdrop-filter`).

## Fix
- **Instant scroll** for tour steps (workspace + comparator).
- **Remove the dim scrim** and make the element-attached **outline + elevation** the spotlight. It tracks the element as the page streams (immune to stacking contexts) and works for the tabbed comparator steps too.

## Verification (live, in-browser)
- Step 4 (workspace `Schema walkthrough`): in view, no scrim.
- Step 5 (comparator, behind the *Compare methods* tab): tab auto-activates, element in view, no scrim.
- e2e **11/11**. No bundle rebuild (`app.js` + `styles.css` load directly).