### PR TITLE
fix(appwrite): stay offline when backend unreachable instead of flooding console

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -4333,19 +4333,42 @@ async function initAppwrite() {
   // initAppwrite entirely and silently disabled share links + persistence.
 
   // Try to ensure a session. account.get() throwing is normal (no session yet);
-  // we then fall back to an anonymous session. If BOTH throw, the backend is
-  // unreachable — project paused, network down, or DNS failure.
-  let sessionOk = false;
-  try { await account.get(); sessionOk = true; }
-  catch { try { await account.createAnonymousSession(); sessionOk = true; } catch (e) { console.warn("Anonymous session unavailable", e.message); } }
+  // we then fall back to an anonymous session. Both are best-effort: with `Any`
+  // collection perms the app runs fine as an unauthenticated guest, so a failed
+  // session must NOT disable realtime/persistence (see docs/appwrite-setup.md
+  // § "Sessions & permissions model"). What we must avoid is calling
+  // client.subscribe() against an *unreachable* backend — that opens a WebSocket
+  // the realtime client then retries every ~1s forever ("Realtime got
+  // disconnected. Reconnect will be attempted in 1 seconds."), flooding the
+  // console. So we gate on reachability, not on whether a session was obtained.
+  //
+  // An Appwrite request that received an HTTP response (even 401/403) carries
+  // that status in `err.code`; a network failure (project paused, offline, DNS)
+  // surfaces as code 0 / a plain fetch error. If the backend answered *either*
+  // call it's reachable.
+  const respondedWithHttpStatus = (err) => typeof err?.code === "number" && err.code > 0;
+  let backendReachable = false;
+  try {
+    await account.get();
+    backendReachable = true; // a session already exists → reachable
+  } catch (getErr) {
+    if (respondedWithHttpStatus(getErr)) backendReachable = true; // 401 (no session) still means reachable
+    try {
+      await account.createAnonymousSession();
+      backendReachable = true;
+    } catch (sessionErr) {
+      if (respondedWithHttpStatus(sessionErr)) backendReachable = true;
+      // Log full error objects (not just .message, which is often empty) so the
+      // auth-vs-network distinction is diagnosable from the console.
+      console.warn("Appwrite session unavailable; continuing as guest if reachable.", { getErr, sessionErr });
+    }
+  }
 
-  // Graceful degradation: when the backend is unreachable, do NOT call
-  // client.subscribe(). The realtime client would otherwise retry the WebSocket
-  // every ~1s indefinitely ("Realtime got disconnected. Reconnect will be
-  // attempted in 1 seconds."), flooding the console. Leaving `appwrite = null`
-  // also makes publishEvent/share/persistence no-op via their
-  // `if (!appwrite) return` guards — i.e. clean offline mode.
-  if (!sessionOk) {
+  // Graceful degradation: when the backend never responded, stay fully offline.
+  // Don't call client.subscribe() (avoids the ~1s reconnect flood) and leave
+  // `appwrite = null` so publishEvent/share/persistence no-op via their existing
+  // `if (!appwrite) return` guards.
+  if (!backendReachable) {
     console.warn("Appwrite backend unreachable; running offline (realtime sync + remote save disabled).");
     return;
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -4332,9 +4332,23 @@ async function initAppwrite() {
   // `new Appwrite.Realtime(client)` threw "is not a constructor", which aborted
   // initAppwrite entirely and silently disabled share links + persistence.
 
-  // Try to ensure a session (optional; public perms will still work without it)
-  try { await account.get(); }
-  catch { try { await account.createAnonymousSession(); } catch (e) { console.warn("Anonymous session unavailable", e.message); } }
+  // Try to ensure a session. account.get() throwing is normal (no session yet);
+  // we then fall back to an anonymous session. If BOTH throw, the backend is
+  // unreachable — project paused, network down, or DNS failure.
+  let sessionOk = false;
+  try { await account.get(); sessionOk = true; }
+  catch { try { await account.createAnonymousSession(); sessionOk = true; } catch (e) { console.warn("Anonymous session unavailable", e.message); } }
+
+  // Graceful degradation: when the backend is unreachable, do NOT call
+  // client.subscribe(). The realtime client would otherwise retry the WebSocket
+  // every ~1s indefinitely ("Realtime got disconnected. Reconnect will be
+  // attempted in 1 seconds."), flooding the console. Leaving `appwrite = null`
+  // also makes publishEvent/share/persistence no-op via their
+  // `if (!appwrite) return` guards — i.e. clean offline mode.
+  if (!sessionOk) {
+    console.warn("Appwrite backend unreachable; running offline (realtime sync + remote save disabled).");
+    return;
+  }
 
   const channel = cfg.channel(cfg.databaseId, cfg.collectionId);
   // SDK v13 accepts a string or string[]; use the canonical array form.


### PR DESCRIPTION
## Problem

`initAppwrite()` (`assets/app.js`) called `client.subscribe([channel], cb)` unconditionally whenever Appwrite was configured. When the project is paused/unreachable (or the user is offline), the Appwrite SDK's realtime client retries the WebSocket every ~1s indefinitely, flooding the console with `Realtime got disconnected. Reconnect will be attempted in 1 seconds.` — **282+ entries observed in a single session.**

## Fix

Gate the realtime subscription on backend reachability. The function already tries `account.get()` and falls back to `createAnonymousSession()`. We now track whether either succeeded (`sessionOk`):

- `account.get()` throwing is normal (no session yet) → fall back to anonymous session.
- If **both** throw, the backend is unreachable → skip `client.subscribe(...)` and leave `appwrite = null`.

Leaving `appwrite = null` makes `publishEvent` / share-link creation / persistence no-op through their existing `if (!appwrite) return` guards — i.e. clean offline mode, no socket opened, no reconnect loop.

The **happy path is unchanged**: when either call succeeds, subscribe + remote save/share run exactly as before.

## Acceptance

- ✅ Backend unreachable → no repeating reconnect errors (the WebSocket is never opened).
- ⏳ Active project → realtime sync + remote save/share still work — **needs live verification before merge.**

## ⚠️ Verification status

- `node --check assets/app.js` passes; the gated `subscribe` call is the only realtime entry point (confirmed by grep).
- **Could NOT test the happy path:** the owner's Appwrite project is currently paused, so only the failure path is testable right now. Before merging, confirm against an **active** project that `createAnonymousSession()` still succeeds and realtime + share-link persistence still work — don't regress the public-perms/anonymous-session path this app relies on. (This touches the historically-fragile Appwrite init.)

### Tradeoff to confirm
The both-throw heuristic treats *any* double-failure as offline. Narrow edge case: backend reachable but anonymous sessions disabled while the collection is public-read — that path now goes offline instead of using public-perms realtime. Matches the prescribed approach (this app relies on anonymous sessions), but worth a glance when the project is unpaused. Can be tightened to gate only on genuine network errors (AppwriteException code 0) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)